### PR TITLE
Add GitHub Stats section to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,6 +112,20 @@ Pipeline CI/CD complet pour automatiser le déploiement de configurations résea
 
 ---
 
+## 📊 GitHub Stats
+
+<div align="center">
+
+![GitHub Stats](https://github-readme-stats.vercel.app/api?username=oumeziane69-prog&show_icons=true&theme=dark&hide_border=true&count_private=true)
+
+![Top Languages](https://github-readme-stats.vercel.app/api/top-langs/?username=oumeziane69-prog&layout=compact&theme=dark&hide_border=true)
+
+![GitHub Streak](https://github-readme-streak-stats.herokuapp.com/?user=oumeziane69-prog&theme=dark&hide_border=true)
+
+</div>
+
+---
+
 ## 📬 Contact
 
 Tu peux me retrouver sur **LinkedIn** ou via mon profil **GitHub** ci-dessus.


### PR DESCRIPTION
## Summary
Added a new "GitHub Stats" section to the README that displays GitHub statistics and activity metrics using embedded badges.

## Changes Made
- Added a new **GitHub Stats** section with three dynamic GitHub statistics widgets:
  - GitHub user stats (contributions, repositories, followers)
  - Top programming languages breakdown
  - GitHub contribution streak counter
- Positioned the new section between the CI/CD Pipeline section and the Contact section
- Used centered alignment for better visual presentation
- Integrated with github-readme-stats and github-readme-streak-stats services

## Implementation Details
- All statistics are dynamically generated and linked to the GitHub user `oumeziane69-prog`
- Applied consistent dark theme styling across all widgets
- Removed borders for a cleaner appearance
- Included private repository counts in the stats display

https://claude.ai/code/session_019s43XhGifZca726HSpz6Rw