### PR TITLE
feat: add auto-merge workflow for claude/* branches

### DIFF
--- a/.github/workflows/auto-merge.yml
+++ b/.github/workflows/auto-merge.yml
@@ -1,0 +1,35 @@
+name: Auto-merge Claude branches
+
+on:
+  pull_request:
+    types: [opened, reopened, synchronize]
+    branches:
+      - main
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  auto-merge:
+    name: Auto-merge claude/* PR
+    runs-on: ubuntu-latest
+    if: startsWith(github.head_ref, 'claude/')
+
+    steps:
+      - name: Merge PR via GitHub API
+        uses: actions/github-script@v7
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const pr = context.payload.pull_request;
+            console.log(`Merging PR #${pr.number}: ${pr.title}`);
+            await github.rest.pulls.merge({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              pull_number: pr.number,
+              merge_method: 'squash',
+              commit_title: pr.title,
+              commit_message: `Auto-merged by GitHub Actions\n\nPR: #${pr.number}`
+            });
+            console.log('Merged successfully.');


### PR DESCRIPTION
Triggers on PR open/reopen/sync targeting main.
Squash-merges via GitHub API when head branch starts with claude/.

https://claude.ai/code/session_019s43XhGifZca726HSpz6Rw