### PR TITLE
fix(ci): handle already-closed PR in auto-merge workflow

### DIFF
--- a/.github/workflows/auto-merge.yml
+++ b/.github/workflows/auto-merge.yml
@@ -23,13 +23,25 @@ jobs:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |
             const pr = context.payload.pull_request;
+            if (pr.state === 'closed') {
+              console.log(`PR #${pr.number} is already closed — skipping merge.`);
+              return;
+            }
             console.log(`Merging PR #${pr.number}: ${pr.title}`);
-            await github.rest.pulls.merge({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              pull_number: pr.number,
-              merge_method: 'squash',
-              commit_title: pr.title,
-              commit_message: `Auto-merged by GitHub Actions\n\nPR: #${pr.number}`
-            });
-            console.log('Merged successfully.');
+            try {
+              await github.rest.pulls.merge({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                pull_number: pr.number,
+                merge_method: 'squash',
+                commit_title: pr.title,
+                commit_message: `Auto-merged by GitHub Actions\n\nPR: #${pr.number}`
+              });
+              console.log('Merged successfully.');
+            } catch (err) {
+              if (err.status === 405 || err.status === 409) {
+                console.log(`Merge skipped (${err.status}): ${err.message}`);
+              } else {
+                throw err;
+              }
+            }


### PR DESCRIPTION
Add guard clause and catch 405/409 errors so the workflow does not fail when the PR is already merged or not mergeable.

https://claude.ai/code/session_014AKPA2TyaWHzVnbgMMWPku