### PR TITLE
ci: auto-delete claude/* branches after PR merge

### DIFF
--- a/.github/workflows/delete-merged-branches.yml
+++ b/.github/workflows/delete-merged-branches.yml
@@ -1,0 +1,32 @@
+name: Delete branch after merge
+
+on:
+  pull_request:
+    types: [closed]
+
+permissions:
+  contents: write
+
+jobs:
+  delete-branch:
+    name: Delete merged claude/* branch
+    runs-on: ubuntu-latest
+    if: github.event.pull_request.merged == true && startsWith(github.event.pull_request.head.ref, 'claude/')
+
+    steps:
+      - name: Delete head branch
+        uses: actions/github-script@v7
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const branch = context.payload.pull_request.head.ref;
+            try {
+              await github.rest.git.deleteRef({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                ref: `heads/${branch}`
+              });
+              console.log(`Deleted branch: ${branch}`);
+            } catch (err) {
+              console.log(`Could not delete branch ${branch}: ${err.message}`);
+            }


### PR DESCRIPTION
## Summary

- Adds `.github/workflows/delete-merged-branches.yml` : supprime automatiquement la branche `claude/*` dès qu'une PR est mergée, empêchant l'accumulation de branches orphelines

## Context

Audit du 2026-04-12 : 22 branches `claude/*` orphelines détectées sur le dépôt. Ce workflow règle le problème à la source pour toutes les futures branches.

## Cleanup manuel requis

Les 22 branches orphelines existantes doivent être supprimées manuellement via GitHub UI (Settings → Branches) ou via l'API, car `git push --delete` est bloqué (403) par le proxy en session web.

Liste des branches à supprimer :
- `claude/add-gitignore-claude-md-K9mX3`
- `claude/add-netdevops-training-Z6cXH`
- `claude/add-youtube-button`
- `claude/add-youtube-header-badge`
- `claude/add-youtube-link`
- `claude/auto-merge-setup-001`
- `claude/fix-readme-skills-001`
- `claude/fix-readme-skills-badges-YWdse`
- `claude/fix-script-loading-order-BUQgq`
- `claude/fix-scroll-simple`
- `claude/github-stats-section-4JdFa`
- `claude/improve-scroll-zoom`
- `claude/readd-scroll-buttons`
- `claude/replace-formation-html`
- `claude/scroll-speed-05`
- `claude/slow-scroll-speed-QQuhq`
- `claude/test-automerge-001`
- `claude/update-cv`
- `claude/update-cv-v2`
- `claude/update-youtube-link-ZMCO7`
- `claude/update-youtube-link-v3`
- `claude/zoom-125`

## Test plan

- [ ] Merger cette PR → vérifier que la branche `claude/cleanup-orphan-branches-R8wQx` est supprimée automatiquement
- [ ] Supprimer manuellement les 22 branches orphelines listées ci-dessus

https://claude.ai/code/session_01PcZGqxacMjUBGxioYgNdDc