### PR TITLE
docs: Add NetDevOps pipeline documentation for deploy_safe.py & vault.py

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,6 +87,56 @@ Claude AI  ──►  Claude Code  ──►  GitHub Actions  ──►  Netmiko
 
 ---
 
+## 🚀 Pipeline NetDevOps — `deploy_safe.py` & `vault.py`
+
+**FR** — Ce pipeline bout-en-bout automatise le déploiement sécurisé de configurations sur équipements réseau physiques, avec des mécanismes de protection à chaque étape.
+
+**EN** — This end-to-end pipeline automates the secure deployment of configurations to physical network devices, with protection mechanisms at every stage.
+
+### Flux complet / Full Flow
+
+```
+Claude AI  ──►  Claude Code  ──►  GitHub Actions  ──►  Netmiko  ──►  Équipements
+(stratégie)    (génère+push)      (validation CI)      (Python)       (déploiement)
+```
+
+### `deploy_safe.py` — Déploiement sécurisé / Safe Deployment
+
+| Fonctionnalité 🇫🇷 | Feature 🇬🇧 |
+|---|---|
+| 📸 Snapshot pré-déploiement (`show run`) | 📸 Pre-deploy snapshot (`show run`) |
+| 🔍 Mode dry-run (simulation sans appliquer) | 🔍 Dry-run mode (simulate without applying) |
+| ↩️ Rollback automatique en cas d'échec | ↩️ Automatic rollback on failure |
+| 📋 Journalisation horodatée de chaque opération | 📋 Timestamped logging of every operation |
+
+**FR** — Avant tout déploiement, `deploy_safe.py` capture l'état courant de l'équipement (snapshot), exécute les commandes en mode dry-run pour validation, puis applique la configuration. En cas d'erreur détectée, le script restaure automatiquement le snapshot précédent via Netmiko.
+
+**EN** — Before any deployment, `deploy_safe.py` captures the current device state (snapshot), runs commands in dry-run mode for validation, then applies the configuration. If an error is detected, the script automatically restores the previous snapshot via Netmiko.
+
+### `vault.py` — Chiffrement des secrets / Secrets Encryption
+
+| Fonctionnalité 🇫🇷 | Feature 🇬🇧 |
+|---|---|
+| 🔐 Chiffrement Fernet (AES-128-CBC + HMAC) | 🔐 Fernet encryption (AES-128-CBC + HMAC) |
+| 🗄️ Stockage sécurisé des credentials SSH/Telnet | 🗄️ Secure storage of SSH/Telnet credentials |
+| 🔑 Clé dérivée depuis variable d'environnement | 🔑 Key derived from environment variable |
+| 🚫 Aucune donnée sensible en clair dans le dépôt | 🚫 No plaintext sensitive data in the repository |
+
+**FR** — `vault.py` utilise la bibliothèque `cryptography` avec l'algorithme Fernet pour chiffrer les identifiants SSH/Telnet des équipements. La clé de chiffrement est injectée via une variable d'environnement (`VAULT_KEY`) ou un secret GitHub Actions — jamais stockée dans le code.
+
+**EN** — `vault.py` uses the `cryptography` library with the Fernet algorithm to encrypt SSH/Telnet device credentials. The encryption key is injected via an environment variable (`VAULT_KEY`) or a GitHub Actions secret — never stored in code.
+
+```python
+# vault.py — usage example (no real credentials committed)
+vault = Vault(key=os.environ["VAULT_KEY"])
+creds = vault.decrypt("<ENCRYPTED-BLOB-HERE>")
+# deploy_safe.py uses creds to connect via Netmiko
+```
+
+`Python` `Netmiko` `Fernet` `GitHub Actions` `Cisco IOS` `CI/CD`
+
+---
+
 ## 📊 Compétences clés / Key Skills
 
 | 🇫🇷 Compétence | 🇬🇧 Skill |


### PR DESCRIPTION
## Summary
This PR adds comprehensive documentation to the README for the secure network device deployment pipeline, including details about the `deploy_safe.py` safe deployment module and `vault.py` secrets encryption module.

## Changes Made
- **Added NetDevOps Pipeline section** with bilingual (FR/EN) documentation explaining the end-to-end deployment workflow from Claude AI through GitHub Actions to physical network equipment via Netmiko
- **Documented `deploy_safe.py`** features including:
  - Pre-deployment snapshots of device configurations
  - Dry-run mode for safe validation without applying changes
  - Automatic rollback on deployment failures
  - Timestamped operation logging
- **Documented `vault.py`** security features including:
  - Fernet encryption (AES-128-CBC + HMAC) for credentials
  - Secure SSH/Telnet credential storage
  - Environment variable-based key management
  - Zero plaintext secrets in repository
- **Added code example** showing vault usage pattern with Netmiko integration
- **Included relevant technology tags** (`Python`, `Netmiko`, `Fernet`, `GitHub Actions`, `Cisco IOS`, `CI/CD`)

## Implementation Details
The documentation maintains the existing bilingual format of the README and follows the established visual hierarchy with emoji indicators and comparison tables. The pipeline flow diagram clearly shows the integration points between Claude AI, GitHub Actions, and network device deployment via Netmiko.

https://claude.ai/code/session_01EYf2JhfMSqRPHZupCuBBVg