### PR TITLE
feat: add juniper-junos-basics, transmission, and mpls-traffic-engineering labs

### DIFF
--- a/labs/routing/juniper-junos-basics/README.md
+++ b/labs/routing/juniper-junos-basics/README.md
@@ -1,0 +1,79 @@
+# Lab — Juniper JunOS Basics
+
+## Objectif / Objective
+
+**FR** — Prendre en main la CLI Junos et l'architecture hiérarchique de configuration des équipements Juniper (vSRX). Configurer des sessions BGP eBGP entre deux routeurs Juniper vSRX et un routeur Cisco IOS, et comprendre les différences fondamentales de syntaxe et de philosophie entre IOS et JunOS.
+
+**EN** — Get hands-on with the Junos CLI and its hierarchical configuration architecture on Juniper vSRX devices. Configure eBGP sessions between two Juniper vSRX routers and a Cisco IOS router, and understand the fundamental syntax and philosophy differences between IOS and JunOS.
+
+---
+
+## Comparaison IOS vs JunOS / IOS vs JunOS Comparison
+
+| Aspect | Cisco IOS | Juniper JunOS |
+|--------|-----------|---------------|
+| **Mode de config** | Ligne par ligne, immédiat | Hiérarchique, transaction validée par `commit` |
+| **Annulation** | `no <commande>` pour chaque ligne | `rollback N` (50 versions conservées) |
+| **Validation** | Immédiate dès saisie | Candidat config → `commit confirm` → actif |
+| **Nommage interfaces** | `GigabitEthernet0/0` | `ge-0/0/0` (FPC/PIC/Port) |
+| **Sécurité** | IOS ZBF (optionnel) | Security zones + policies (natif sur SRX) |
+| **Filtres** | ACL (`access-list`) | Firewall filters (stateless) + security policies (stateful) |
+| **BGP policy** | `route-map` + `prefix-list` | `policy-statement` + `prefix-list` |
+| **Debug** | `debug ip bgp` | `traceoptions` dans la hiérarchie `protocols bgp` |
+
+---
+
+## Topologie / Topology
+
+Voir [topology.md](topology.md)
+
+```
+SRX1 (AS 65001)  ←──eBGP──→  SRX2 (AS 65002)
+       ↕  eBGP                     ↕  eBGP
+      R1-Cisco (AS 65003)  ←──────┘
+```
+
+---
+
+## Statut / Status
+
+🚧 En cours de construction
+
+---
+
+## Technologies utilisées / Technologies Used
+
+| Technologie | Rôle |
+|-------------|------|
+| Juniper vSRX (JunOS 21.x) | Routeur/firewall — noeud BGP AS 65001 et 65002 |
+| Cisco IOS-XE | Routeur — noeud BGP AS 65003 (interopérabilité) |
+| BGP-4 eBGP (RFC 4271) | Protocole de routage inter-AS |
+| Firewall filters JunOS | Protection du routing engine (PROTECT-RE) |
+| Security zones JunOS | Segmentation et contrôle des flux sur SRX |
+| EVE-NG / GNS3 | Environnement de simulation réseau |
+| Python / Netmiko | Automatisation (optionnel) |
+
+---
+
+## Fichiers du lab / Lab Files
+
+| Fichier | Description |
+|---------|-------------|
+| [topology.md](topology.md) | Plan d'adressage, schéma, description des équipements |
+| [configs/SRX1.junos](configs/SRX1.junos) | Configuration complète SRX1 (AS 65001) |
+| [configs/SRX2.junos](configs/SRX2.junos) | Configuration complète SRX2 (AS 65002) |
+| [configs/R1-cisco.ios](configs/R1-cisco.ios) | Configuration Cisco IOS R1 (AS 65003) |
+| [junos-vs-ios-cheatsheet.md](junos-vs-ios-cheatsheet.md) | Tableau comparatif CLI IOS ↔ JunOS |
+| [verification.md](verification.md) | Commandes `show` JunOS avec output attendu |
+
+---
+
+## Concepts couverts / Concepts Covered
+
+- CLI Junos : modes opérationnel et configuration, navigation dans la hiérarchie
+- `commit`, `commit confirm`, `rollback`, `show | compare`
+- Firewall filters JunOS vs ACL IOS : différences et application
+- Security zones et policies sur vSRX
+- Configuration BGP eBGP avec authentification MD5
+- Export/import policies : `policy-statement` + `prefix-list`
+- Interopérabilité Juniper ↔ Cisco sur une session BGP eBGP

--- a/labs/routing/juniper-junos-basics/configs/R1-cisco.ios
+++ b/labs/routing/juniper-junos-basics/configs/R1-cisco.ios
@@ -1,0 +1,124 @@
+! ============================================================
+! Cisco IOS-XE Configuration — R1
+! Hostname   : R1-Cisco
+! Platform   : Cisco IOS-XE 16.x (CSR1000v or IOSv)
+! AS         : 65003
+! Loopback   : 10.255.3.1/32
+! Gi0/0      : 10.0.13.2/30 — Link to SRX1 (AS 65001)
+! Gi0/1      : 10.0.23.2/30 — Link to SRX2 (AS 65002)
+!
+! SECURITY NOTE: All passwords are placeholders.
+! Replace <BGP-PASSWORD-HERE> and <ADMIN-PASSWORD-HERE>
+! with values from your vault / .env file.
+! Never commit real credentials to this repository.
+! ============================================================
+
+!
+service password-encryption
+no ip http server
+no ip http secure-server
+!
+hostname R1-Cisco
+!
+! ── AAA / USER ─────────────────────────────────────────────
+username admin privilege 15 secret <ADMIN-PASSWORD-HERE>
+!
+! ── INTERFACES ─────────────────────────────────────────────
+interface Loopback0
+ description R1 Router-ID and BGP source
+ ip address 10.255.3.1 255.255.255.255
+ no shutdown
+!
+interface GigabitEthernet0/0
+ description Link to SRX1 ge-0/0/1 (AS65001) - 10.0.13.0/30
+ ip address 10.0.13.2 255.255.255.252
+ ip access-group PROTECT-RE in
+ no shutdown
+!
+interface GigabitEthernet0/1
+ description Link to SRX2 ge-0/0/1 (AS65002) - 10.0.23.0/30
+ ip address 10.0.23.2 255.255.255.252
+ ip access-group PROTECT-RE in
+ no shutdown
+!
+! ── ROUTING ────────────────────────────────────────────────
+ip route 10.255.0.0 255.255.0.0 Null0  ! Aggregate static — prevents BGP blackhole
+!
+! ── BGP ────────────────────────────────────────────────────
+! IOS equivalent of Junos hierarchical BGP config.
+! Note: IOS uses 'neighbor' commands under 'router bgp' stanza.
+! Junos equivalent: protocols { bgp { group { neighbor } } }
+!
+router bgp 65003
+ bgp router-id 10.255.3.1
+ bgp log-neighbor-changes
+ !
+ ! eBGP neighbor: SRX1 (AS 65001)
+ neighbor 10.0.13.1 remote-as 65001
+ neighbor 10.0.13.1 description SRX1-Juniper (AS65001)
+ neighbor 10.0.13.1 password <BGP-PASSWORD-HERE>
+ !   IOS: 'password' = Junos: 'authentication-key' — both use MD5
+ neighbor 10.0.13.1 route-map IMPORT-FROM-EBGP in
+ neighbor 10.0.13.1 route-map EXPORT-LOOPBACK out
+ neighbor 10.0.13.1 soft-reconfiguration inbound
+ !
+ ! eBGP neighbor: SRX2 (AS 65002)
+ neighbor 10.0.23.1 remote-as 65002
+ neighbor 10.0.23.1 description SRX2-Juniper (AS65002)
+ neighbor 10.0.23.1 password <BGP-PASSWORD-HERE>
+ neighbor 10.0.23.1 route-map IMPORT-FROM-EBGP in
+ neighbor 10.0.23.1 route-map EXPORT-LOOPBACK out
+ neighbor 10.0.23.1 soft-reconfiguration inbound
+ !
+ ! Advertise own loopback network
+ network 10.255.3.1 mask 255.255.255.255
+!
+! ── PREFIX-LISTS ───────────────────────────────────────────
+! IOS prefix-list = Junos prefix-list (same concept, different syntax)
+!
+ip prefix-list LOOPBACK-OWN seq 10 permit 10.255.3.1/32
+ip prefix-list LOOPBACK-RANGE seq 10 permit 10.255.0.0/16 le 32
+!
+! ── ROUTE-MAPS ─────────────────────────────────────────────
+! IOS route-map = Junos policy-statement
+! IOS 'match' = Junos 'from', IOS 'set' = Junos 'then'
+!
+route-map EXPORT-LOOPBACK permit 10
+ description Export only own loopback /32 to eBGP peers
+ match ip address prefix-list LOOPBACK-OWN
+!
+route-map IMPORT-FROM-EBGP permit 10
+ description Accept only /32 loopbacks from eBGP peers
+ match ip address prefix-list LOOPBACK-RANGE
+ set local-preference 100
+!
+! ── ACCESS-LISTS (PROTECT-RE) ──────────────────────────────
+! IOS ACL = Junos firewall filter PROTECT-RE
+! Applied inbound on both transit interfaces.
+!
+ip access-list extended PROTECT-RE
+ 10 permit tcp any any eq bgp                    ! Allow BGP TCP/179
+ 20 permit tcp 192.168.0.0 0.0.0.255 any eq 22  ! Allow SSH from OOB management
+ 30 permit icmp any any echo                     ! Allow ping
+ 40 permit icmp any any echo-reply
+ 50 permit icmp any any unreachable
+ 60 permit icmp any any time-exceeded            ! Allow traceroute
+ 999 deny ip any any log                         ! Deny and log everything else
+!
+! ── SSH HARDENING ──────────────────────────────────────────
+ip domain-name lab.local
+crypto key generate rsa modulus 2048             ! Required for SSHv2
+ip ssh version 2
+ip ssh time-out 60
+ip ssh authentication-retries 3
+!
+line vty 0 4
+ transport input ssh                             ! SSH only — no Telnet
+ login local
+ exec-timeout 10 0
+!
+line con 0
+ login local
+ exec-timeout 15 0
+!
+end

--- a/labs/routing/juniper-junos-basics/configs/SRX1.junos
+++ b/labs/routing/juniper-junos-basics/configs/SRX1.junos
@@ -1,0 +1,308 @@
+## ============================================================
+## JunOS Configuration — SRX1
+## Hostname   : SRX1
+## Platform   : Juniper vSRX 21.4R1.12
+## AS         : 65001
+## Loopback   : 10.255.1.1/32
+## ge-0/0/0   : 10.0.12.1/30 — Link to SRX2 (AS 65002)
+## ge-0/0/1   : 10.0.13.1/30 — Link to R1-Cisco (AS 65003)
+##
+## SECURITY NOTE: All passwords are placeholders.
+## Replace <BGP-PASSWORD-HERE> and <ADMIN-PASSWORD-HERE>
+## with values from your secrets manager or .env file.
+## Never commit real credentials to this repository.
+## ============================================================
+
+version 21.4R1.12;
+
+## ── SYSTEM ────────────────────────────────────────────────
+system {
+    host-name SRX1;
+    root-authentication {
+        encrypted-password "<ADMIN-PASSWORD-HERE>";  ## juniper-style $6$ hash — use 'set system root-authentication plain-text-password'
+    }
+    login {
+        user admin {
+            uid 2000;
+            class super-user;
+            authentication {
+                encrypted-password "<ADMIN-PASSWORD-HERE>";
+            }
+        }
+    }
+    services {
+        ssh {
+            root-login deny;                ## Never allow root SSH
+            protocol-version v2;
+            max-sessions-per-connection 10;
+            connection-limit 10;
+        }
+        netconf {
+            ssh;                            ## Enable NETCONF over SSH (port 830)
+        }
+    }
+    syslog {
+        user * {
+            any emergency;
+        }
+        file messages {
+            any notice;
+            authorization info;
+        }
+        file interactive-commands {
+            interactive-commands any;
+        }
+    }
+    ntp {
+        server 192.168.0.1;                 ## OOB NTP server — adjust to your management network
+    }
+}
+
+## ── INTERFACES ────────────────────────────────────────────
+interfaces {
+    ge-0/0/0 {
+        description "Link to SRX2 ge-0/0/0 (AS65002) — 10.0.12.0/30";
+        unit 0 {
+            family inet {
+                filter {
+                    input PROTECT-RE;       ## Stateless filter on transit interface
+                }
+                address 10.0.12.1/30;
+            }
+        }
+    }
+    ge-0/0/1 {
+        description "Link to R1-Cisco Gi0/0 (AS65003) — 10.0.13.0/30";
+        unit 0 {
+            family inet {
+                filter {
+                    input PROTECT-RE;
+                }
+                address 10.0.13.1/30;
+            }
+        }
+    }
+    lo0 {
+        unit 0 {
+            description "SRX1 Router-ID and BGP source";
+            family inet {
+                filter {
+                    input PROTECT-RE;       ## Protect RE from unauthorized traffic
+                }
+                address 10.255.1.1/32;
+            }
+        }
+    }
+}
+
+## ── FIREWALL FILTERS (stateless ACL equivalent) ───────────
+## Applied to interfaces to protect the Routing Engine.
+## Junos firewall filters are stateless — unlike security policies.
+## IOS equivalent: extended ACL applied inbound on interfaces.
+firewall {
+    family inet {
+        filter PROTECT-RE {
+            ##
+            ## Term order matters — first match wins (same as IOS ACL)
+            ##
+            term ALLOW-BGP {
+                from {
+                    protocol tcp;
+                    destination-port bgp;   ## TCP/179
+                }
+                then accept;
+            }
+            term ALLOW-SSH-FROM-MGMT {
+                from {
+                    source-address {
+                        192.168.0.0/24;     ## OOB management network — adjust as needed
+                    }
+                    protocol tcp;
+                    destination-port ssh;   ## TCP/22
+                }
+                then accept;
+            }
+            term ALLOW-ICMP {
+                from {
+                    protocol icmp;
+                    icmp-type [
+                        echo-request        ## ping
+                        echo-reply
+                        unreachable
+                        time-exceeded       ## traceroute
+                    ];
+                }
+                then accept;
+            }
+            term DENY-ALL {
+                then {
+                    discard;                ## Drop silently (no ICMP unreachable)
+                    count DENY-ALL-COUNT;   ## Counter — visible in 'show firewall filter PROTECT-RE'
+                    log;                    ## Log to firewall log buffer
+                    syslog;                 ## Log to syslog
+                }
+            }
+        }
+    }
+}
+
+## ── ROUTING OPTIONS ───────────────────────────────────────
+routing-options {
+    router-id 10.255.1.1;
+    autonomous-system 65001;
+    static {
+        route 10.255.0.0/16 discard;       ## Aggregate for loopback space — prevents BGP blackhole
+    }
+}
+
+## ── PROTOCOLS ─────────────────────────────────────────────
+protocols {
+    bgp {
+        log-updown;                         ## Log neighbor state changes to syslog
+        graceful-restart;                   ## BGP graceful restart (RFC 4724)
+
+        ## eBGP group toward SRX2 (AS 65002)
+        group EBGP-TO-SRX2 {
+            type external;
+            description "eBGP peering with SRX2 (AS65002)";
+            peer-as 65002;
+            authentication-key "<BGP-PASSWORD-HERE>";   ## MD5 auth — IOS equivalent: neighbor x password x
+            neighbor 10.0.12.2 {
+                description "SRX2 (AS65002) — connected on ge-0/0/0";
+                import IMPORT-EBGP;         ## Inbound policy
+                export EXPORT-LOOPBACK;     ## Outbound policy
+            }
+        }
+
+        ## eBGP group toward R1-Cisco (AS 65003)
+        group EBGP-TO-R1 {
+            type external;
+            description "eBGP peering with R1-Cisco (AS65003)";
+            peer-as 65003;
+            authentication-key "<BGP-PASSWORD-HERE>";
+            neighbor 10.0.13.2 {
+                description "R1-Cisco (AS65003) — connected on ge-0/0/1";
+                import IMPORT-EBGP;
+                export EXPORT-LOOPBACK;
+            }
+        }
+    }
+}
+
+## ── POLICY OPTIONS ────────────────────────────────────────
+## Junos equivalent of IOS route-map + prefix-list.
+## Policies are applied per neighbor as import (inbound) and export (outbound).
+policy-options {
+
+    prefix-list LOOPBACK-RANGE {
+        10.255.0.0/16;
+    }
+
+    ## Export policy: announce only own loopback /32 to eBGP peers
+    policy-statement EXPORT-LOOPBACK {
+        term EXPORT-OWN-LOOPBACK {
+            from {
+                protocol direct;
+                route-filter 10.255.1.1/32 exact;
+            }
+            then accept;
+        }
+        term DENY-EVERYTHING-ELSE {
+            then reject;
+        }
+    }
+
+    ## Import policy: accept only loopback /32 prefixes from peers
+    policy-statement IMPORT-EBGP {
+        term ACCEPT-LOOPBACKS {
+            from {
+                prefix-list LOOPBACK-RANGE;
+                route-filter 10.255.0.0/16 prefix-length-range /32-/32;    ## only /32 loopbacks
+            }
+            then {
+                local-preference 100;
+                accept;
+            }
+        }
+        term DENY-ALL {
+            then reject;
+        }
+    }
+}
+
+## ── SECURITY ──────────────────────────────────────────────
+## SRX uses security zones and policies (stateful).
+## This is different from firewall filters above (stateless).
+## IOS equivalent: Zone-Based Firewall (ZBF).
+security {
+    zones {
+        ## UNTRUST zone: external BGP peer interfaces
+        security-zone UNTRUST {
+            description "External BGP peering interfaces";
+            interfaces {
+                ge-0/0/0.0 {
+                    host-inbound-traffic {
+                        system-services {
+                            bgp;
+                            ping;
+                            traceroute;
+                        }
+                    }
+                }
+                ge-0/0/1.0 {
+                    host-inbound-traffic {
+                        system-services {
+                            bgp;
+                            ping;
+                            traceroute;
+                        }
+                    }
+                }
+            }
+        }
+        ## MANAGEMENT zone: loopback — all management services allowed
+        security-zone MANAGEMENT {
+            description "Loopback — management and routing engine";
+            interfaces {
+                lo0.0 {
+                    host-inbound-traffic {
+                        system-services {
+                            all;
+                        }
+                        protocols {
+                            all;
+                        }
+                    }
+                }
+            }
+        }
+    }
+    ## Default policy: deny all inter-zone traffic not explicitly permitted
+    policies {
+        default-policy {
+            deny-all;
+        }
+    }
+    ## IDS screens on UNTRUST zone — basic DoS protection
+    screen {
+        ids-option UNTRUST-SCREEN {
+            icmp {
+                ping-death;
+            }
+            ip {
+                source-route-option;
+                tear-drop;
+            }
+            tcp {
+                syn-flood {
+                    alarm-threshold 1024;
+                    attack-threshold 200;
+                    source-threshold 1024;
+                    destination-threshold 2048;
+                    timeout 20;
+                }
+                land;
+            }
+        }
+    }
+}

--- a/labs/routing/juniper-junos-basics/configs/SRX2.junos
+++ b/labs/routing/juniper-junos-basics/configs/SRX2.junos
@@ -1,0 +1,292 @@
+## ============================================================
+## JunOS Configuration — SRX2
+## Hostname   : SRX2
+## Platform   : Juniper vSRX 21.4R1.12
+## AS         : 65002
+## Loopback   : 10.255.2.1/32
+## ge-0/0/0   : 10.0.12.2/30 — Link to SRX1 (AS 65001)
+## ge-0/0/1   : 10.0.23.1/30 — Link to R1-Cisco (AS 65003)
+##
+## SECURITY NOTE: All passwords are placeholders.
+## Replace <BGP-PASSWORD-HERE> and <ADMIN-PASSWORD-HERE>
+## with values from your secrets manager or .env file.
+## Never commit real credentials to this repository.
+## ============================================================
+
+version 21.4R1.12;
+
+## ── SYSTEM ────────────────────────────────────────────────
+system {
+    host-name SRX2;
+    root-authentication {
+        encrypted-password "<ADMIN-PASSWORD-HERE>";
+    }
+    login {
+        user admin {
+            uid 2000;
+            class super-user;
+            authentication {
+                encrypted-password "<ADMIN-PASSWORD-HERE>";
+            }
+        }
+    }
+    services {
+        ssh {
+            root-login deny;
+            protocol-version v2;
+            max-sessions-per-connection 10;
+            connection-limit 10;
+        }
+        netconf {
+            ssh;
+        }
+    }
+    syslog {
+        user * {
+            any emergency;
+        }
+        file messages {
+            any notice;
+            authorization info;
+        }
+        file interactive-commands {
+            interactive-commands any;
+        }
+    }
+    ntp {
+        server 192.168.0.1;
+    }
+}
+
+## ── INTERFACES ────────────────────────────────────────────
+interfaces {
+    ge-0/0/0 {
+        description "Link to SRX1 ge-0/0/0 (AS65001) — 10.0.12.0/30";
+        unit 0 {
+            family inet {
+                filter {
+                    input PROTECT-RE;
+                }
+                address 10.0.12.2/30;
+            }
+        }
+    }
+    ge-0/0/1 {
+        description "Link to R1-Cisco Gi0/1 (AS65003) — 10.0.23.0/30";
+        unit 0 {
+            family inet {
+                filter {
+                    input PROTECT-RE;
+                }
+                address 10.0.23.1/30;
+            }
+        }
+    }
+    lo0 {
+        unit 0 {
+            description "SRX2 Router-ID and BGP source";
+            family inet {
+                filter {
+                    input PROTECT-RE;
+                }
+                address 10.255.2.1/32;
+            }
+        }
+    }
+}
+
+## ── FIREWALL FILTERS ──────────────────────────────────────
+firewall {
+    family inet {
+        filter PROTECT-RE {
+            term ALLOW-BGP {
+                from {
+                    protocol tcp;
+                    destination-port bgp;
+                }
+                then accept;
+            }
+            term ALLOW-SSH-FROM-MGMT {
+                from {
+                    source-address {
+                        192.168.0.0/24;
+                    }
+                    protocol tcp;
+                    destination-port ssh;
+                }
+                then accept;
+            }
+            term ALLOW-ICMP {
+                from {
+                    protocol icmp;
+                    icmp-type [
+                        echo-request
+                        echo-reply
+                        unreachable
+                        time-exceeded
+                    ];
+                }
+                then accept;
+            }
+            term DENY-ALL {
+                then {
+                    discard;
+                    count DENY-ALL-COUNT;
+                    log;
+                    syslog;
+                }
+            }
+        }
+    }
+}
+
+## ── ROUTING OPTIONS ───────────────────────────────────────
+routing-options {
+    router-id 10.255.2.1;
+    autonomous-system 65002;
+    static {
+        route 10.255.0.0/16 discard;
+    }
+}
+
+## ── PROTOCOLS ─────────────────────────────────────────────
+protocols {
+    bgp {
+        log-updown;
+        graceful-restart;
+
+        ## eBGP group toward SRX1 (AS 65001)
+        ## Note: peer-as on SRX2 side must match SRX1's AS (65001)
+        group EBGP-TO-SRX1 {
+            type external;
+            description "eBGP peering with SRX1 (AS65001)";
+            peer-as 65001;
+            authentication-key "<BGP-PASSWORD-HERE>";   ## Must match SRX1 authentication-key
+            neighbor 10.0.12.1 {
+                description "SRX1 (AS65001) — connected on ge-0/0/0";
+                import IMPORT-EBGP;
+                export EXPORT-LOOPBACK;
+            }
+        }
+
+        ## eBGP group toward R1-Cisco (AS 65003)
+        group EBGP-TO-R1 {
+            type external;
+            description "eBGP peering with R1-Cisco (AS65003)";
+            peer-as 65003;
+            authentication-key "<BGP-PASSWORD-HERE>";
+            neighbor 10.0.23.2 {
+                description "R1-Cisco (AS65003) — connected on ge-0/0/1";
+                import IMPORT-EBGP;
+                export EXPORT-LOOPBACK;
+            }
+        }
+    }
+}
+
+## ── POLICY OPTIONS ────────────────────────────────────────
+policy-options {
+
+    prefix-list LOOPBACK-RANGE {
+        10.255.0.0/16;
+    }
+
+    policy-statement EXPORT-LOOPBACK {
+        term EXPORT-OWN-LOOPBACK {
+            from {
+                protocol direct;
+                route-filter 10.255.2.1/32 exact;      ## Only export SRX2 own loopback
+            }
+            then accept;
+        }
+        term DENY-EVERYTHING-ELSE {
+            then reject;
+        }
+    }
+
+    policy-statement IMPORT-EBGP {
+        term ACCEPT-LOOPBACKS {
+            from {
+                prefix-list LOOPBACK-RANGE;
+                route-filter 10.255.0.0/16 prefix-length-range /32-/32;
+            }
+            then {
+                local-preference 100;
+                accept;
+            }
+        }
+        term DENY-ALL {
+            then reject;
+        }
+    }
+}
+
+## ── SECURITY ──────────────────────────────────────────────
+security {
+    zones {
+        security-zone UNTRUST {
+            description "External BGP peering interfaces";
+            interfaces {
+                ge-0/0/0.0 {
+                    host-inbound-traffic {
+                        system-services {
+                            bgp;
+                            ping;
+                            traceroute;
+                        }
+                    }
+                }
+                ge-0/0/1.0 {
+                    host-inbound-traffic {
+                        system-services {
+                            bgp;
+                            ping;
+                            traceroute;
+                        }
+                    }
+                }
+            }
+        }
+        security-zone MANAGEMENT {
+            description "Loopback — management and routing engine";
+            interfaces {
+                lo0.0 {
+                    host-inbound-traffic {
+                        system-services {
+                            all;
+                        }
+                        protocols {
+                            all;
+                        }
+                    }
+                }
+            }
+        }
+    }
+    policies {
+        default-policy {
+            deny-all;
+        }
+    }
+    screen {
+        ids-option UNTRUST-SCREEN {
+            icmp {
+                ping-death;
+            }
+            ip {
+                source-route-option;
+                tear-drop;
+            }
+            tcp {
+                syn-flood {
+                    alarm-threshold 1024;
+                    attack-threshold 200;
+                    source-threshold 1024;
+                    destination-threshold 2048;
+                    timeout 20;
+                }
+                land;
+            }
+        }
+    }
+}

--- a/labs/routing/juniper-junos-basics/junos-vs-ios-cheatsheet.md
+++ b/labs/routing/juniper-junos-basics/junos-vs-ios-cheatsheet.md
@@ -1,0 +1,133 @@
+# JunOS vs IOS CLI Cheatsheet
+
+> Référence rapide pour les ingénieurs réseau IOS souhaitant prendre en main JunOS.
+> Quick reference for IOS network engineers getting started with JunOS.
+
+---
+
+## 1. Modes CLI / CLI Modes
+
+| Action | Cisco IOS | Juniper JunOS |
+|--------|-----------|---------------|
+| Mode opérationnel (show, ping...) | Mode `>` par défaut | Mode `>` (`cli` depuis shell root) |
+| Entrer en configuration | `configure terminal` / `conf t` | `configure` / `edit` |
+| Quitter la config (sans sauver) | `end` ou `Ctrl+Z` | `exit discard` ou `rollback 0; exit` |
+| Quitter un niveau de hiérarchie | `exit` | `exit` (remonte d'un niveau) ou `top` (retour racine) |
+| Naviguer dans la hiérarchie | N/A (linéaire) | `edit protocols bgp` pour descendre dans `[edit protocols bgp]` |
+
+---
+
+## 2. Sauvegarde et validation / Save & Commit
+
+| Action | Cisco IOS | Juniper JunOS |
+|--------|-----------|---------------|
+| Appliquer / sauvegarder la config | `copy running-config startup-config` / `wr mem` | `commit` |
+| Valider avec confirmation | N/A | `commit confirmed 5` (rollback auto dans 5 min si pas de 2e commit) |
+| Vérifier avant d'appliquer | `do show run` (partiel) | `show \| compare` (diff candidat vs actif) |
+| Annuler les changements en cours | Annuler ligne par ligne (`no ...`) | `rollback 0` (restaure la config active) |
+| Historique des commits | N/A | `show system commit` (50 versions conservées) |
+| Restaurer une version précédente | `copy flash:backup run` (manuel) | `rollback 3` (restaure la 3e version précédente) |
+| Config active | `show running-config` | `show configuration` |
+| Config sauvegardée | `show startup-config` | `show configuration \| display set` |
+| Diff entre deux versions | N/A | `show system rollback compare 0 1` |
+
+---
+
+## 3. Interfaces
+
+| Action | Cisco IOS | Juniper JunOS |
+|--------|-----------|---------------|
+| Nommage | `GigabitEthernet0/0` (`Gi0/0`) | `ge-0/0/0` (FPC/PIC/Port) |
+| Loopback | `interface Loopback0` | `interfaces lo0 unit 0` |
+| Assigner une IP | `ip address 10.0.1.1 255.255.255.252` | `set interfaces ge-0/0/0 unit 0 family inet address 10.0.1.1/30` |
+| Activer une interface | `no shutdown` | Activée par défaut — désactiver avec `set interfaces ge-0/0/0 disable` |
+| Désactiver | `shutdown` | `set interfaces ge-0/0/0 disable` |
+| Description | `description Lien vers SRX2` | `set interfaces ge-0/0/0 description "Lien vers SRX2"` |
+| Afficher résumé | `show interfaces brief` / `show ip int brief` | `show interfaces terse` |
+| Afficher détail | `show interfaces GigabitEthernet0/0` | `show interfaces ge-0/0/0 detail` |
+| Afficher IP seulement | `show ip interface brief` | `show interfaces terse \| match inet` |
+
+---
+
+## 4. Table de routage / Routing Table
+
+| Action | Cisco IOS | Juniper JunOS |
+|--------|-----------|---------------|
+| Table de routage complète | `show ip route` | `show route` |
+| Route spécifique | `show ip route 10.255.1.1` | `show route 10.255.1.1` |
+| Routes BGP uniquement | `show ip bgp` | `show route protocol bgp` |
+| Routes statiques | `show ip route static` | `show route protocol static` |
+| Table de routage résumée | `show ip route summary` | `show route summary` |
+| Prochains sauts | `show ip route 10.0.0.0/8 longer-prefixes` | `show route 10.0.0.0/8 longer` |
+
+---
+
+## 5. BGP
+
+| Action | Cisco IOS | Juniper JunOS |
+|--------|-----------|---------------|
+| Résumé des voisins | `show ip bgp summary` | `show bgp summary` |
+| Détail d'un voisin | `show ip bgp neighbors 10.0.12.2` | `show bgp neighbor 10.0.12.2` |
+| Routes reçues d'un voisin | `show ip bgp neighbors 10.0.12.2 received-routes` | `show route receive-protocol bgp 10.0.12.2` |
+| Routes envoyées à un voisin | `show ip bgp neighbors 10.0.12.2 advertised-routes` | `show route advertising-protocol bgp 10.0.12.2` |
+| Table BGP complète | `show ip bgp` | `show bgp` |
+| Reset voisin (soft) | `clear ip bgp 10.0.12.2 soft` | `clear bgp neighbor 10.0.12.2 soft [in\|out]` |
+| Reset voisin (hard) | `clear ip bgp 10.0.12.2` | `clear bgp neighbor 10.0.12.2` |
+| Debug BGP | `debug ip bgp 10.0.12.2` | `set protocols bgp traceoptions file bgp-trace` puis `set protocols bgp traceoptions flag all` |
+
+---
+
+## 6. Filtrage / Policy
+
+| Concept IOS | Concept JunOS | Description |
+|-------------|---------------|-------------|
+| `ip prefix-list` | `policy-options prefix-list` | Liste de préfixes IP |
+| `route-map` | `policy-statement` | Politique de routage (match + action) |
+| `match ip address prefix-list X` | `from { prefix-list X; }` | Condition d'entrée |
+| `set local-preference 200` | `then { local-preference 200; }` | Action d'application |
+| `permit` (route-map) | `then accept;` | Accepter le préfixe |
+| `deny` (route-map) | `then reject;` | Rejeter le préfixe |
+| `neighbor X route-map Y in` | `neighbor X { import POLICY; }` | Appliquer policy en entrée |
+| `neighbor X route-map Y out` | `neighbor X { export POLICY; }` | Appliquer policy en sortie |
+
+---
+
+## 7. Filtres et sécurité / Filters & Security
+
+| Concept IOS | Concept JunOS | Description |
+|-------------|---------------|-------------|
+| `ip access-list extended` | `firewall filter` (family inet) | Filtre stateless sur interface |
+| `permit tcp any any eq 179` | `term X { from { protocol tcp; destination-port bgp; } then accept; }` | Autoriser BGP |
+| `deny ip any any log` | `term DENY { then { discard; log; syslog; } }` | Règle de refus finale avec log |
+| `ip access-group ACL in` | `filter { input FILTER-NAME; }` dans la config interface | Application du filtre en entrée |
+| Zone-Based Firewall (ZBF) | Security zones + policies (natif SRX) | Firewall stateful inter-zones |
+
+---
+
+## 8. Diagnostics / Diagnostics
+
+| Action | Cisco IOS | Juniper JunOS |
+|--------|-----------|---------------|
+| Ping | `ping 10.255.2.1` | `ping 10.255.2.1` |
+| Traceroute | `traceroute 10.255.2.1` | `traceroute 10.255.2.1` |
+| Ping source | `ping 10.255.2.1 source Loopback0` | `ping 10.255.2.1 routing-instance default source 10.255.1.1` |
+| Log système | `show logging` | `show log messages` |
+| Log en temps réel | `terminal monitor` | `monitor start messages` |
+| Compteurs interfaces | `show interfaces GigabitEthernet0/0 counters` | `show interfaces ge-0/0/0 statistics` |
+| ARP table | `show arp` | `show arp` |
+| NTP | `show ntp status` | `show ntp status` |
+| Version OS | `show version` | `show version` |
+
+---
+
+## 9. Particularités JunOS à retenir
+
+| Point | Description |
+|-------|-------------|
+| **Candidate config** | Toutes les modifications sont en "candidate config" jusqu'au `commit`. L'équipement tourne toujours sur la config active. |
+| **Commit confirm** | `commit confirmed 5` : si vous n'exécutez pas un 2e `commit` dans 5 min, la config se rollback automatiquement. Utile pour les changements à risque. |
+| **Rollback 50 versions** | JunOS conserve les 50 dernières configurations commitées. `rollback 1` = version précédente. |
+| **`\| display set`** | Affiche la config au format `set` (une ligne par commande) : `show configuration \| display set` |
+| **`\| compare`** | Affiche le diff entre la candidate config et la config active : `show \| compare` |
+| **Hiérarchie** | La config est un arbre. `edit protocols bgp group EBGP` descend dans ce contexte. `top` revient à la racine. |
+| **Interfaces unités** | Chaque interface physique a des unités logiques (`unit 0`, `unit 100`...). Une interface sans `unit 0` n'a pas d'IP. |

--- a/labs/routing/juniper-junos-basics/topology.md
+++ b/labs/routing/juniper-junos-basics/topology.md
@@ -1,0 +1,88 @@
+# Topology — Juniper JunOS Basics Lab
+
+## Schéma logique / Logical Diagram
+
+```
+                    AS 65001
+          ┌─────────────────────────┐
+          │  SRX1 (Juniper vSRX)    │
+          │  Lo0 : 10.255.1.1/32   │
+          │  ge-0/0/0 : 10.0.12.1  │
+          │  ge-0/0/1 : 10.0.13.1  │
+          └──────┬────────┬─────────┘
+                 │ eBGP   │ eBGP
+    10.0.12.0/30 │        │ 10.0.13.0/30
+                 │        │
+          ┌──────┘        └─────────────────┐
+          │                                  │
+  AS 65002│                                  │AS 65003
+┌─────────┴──────────┐              ┌────────┴─────────────┐
+│  SRX2 (Juniper vSRX│              │  R1-Cisco (IOS-XE)   │
+│  Lo0 : 10.255.2.1  │              │  Lo0 : 10.255.3.1/32 │
+│  ge-0/0/0 :        │  eBGP        │  Gi0/0 : 10.0.13.2   │
+│    10.0.12.2       ├──────────────┤  Gi0/1 : 10.0.23.2   │
+│  ge-0/0/1 :        │ 10.0.23.0/30 │                      │
+│    10.0.23.1       │              └──────────────────────┘
+└────────────────────┘
+```
+
+---
+
+## Plan d'adressage / Addressing Plan
+
+### Loopbacks
+
+| Équipement | Interface | Adresse IP | AS BGP |
+|------------|-----------|-----------|--------|
+| SRX1 | lo0.0 | `10.255.1.1/32` | 65001 |
+| SRX2 | lo0.0 | `10.255.2.1/32` | 65002 |
+| R1-Cisco | Loopback0 | `10.255.3.1/32` | 65003 |
+
+### Liens point-à-point / Point-to-Point Links
+
+| Lien | Réseau | SRX1 / SRX2 / R1 | Interface SRX1/SRX2/R1 |
+|------|--------|------------------|------------------------|
+| SRX1 ↔ SRX2 | `10.0.12.0/30` | SRX1: `10.0.12.1` — SRX2: `10.0.12.2` | SRX1: ge-0/0/0 — SRX2: ge-0/0/0 |
+| SRX1 ↔ R1 | `10.0.13.0/30` | SRX1: `10.0.13.1` — R1: `10.0.13.2` | SRX1: ge-0/0/1 — R1: Gi0/0 |
+| SRX2 ↔ R1 | `10.0.23.0/30` | SRX2: `10.0.23.1` — R1: `10.0.23.2` | SRX2: ge-0/0/1 — R1: Gi0/1 |
+
+---
+
+## Sessions BGP / BGP Sessions
+
+| Peer 1 | Peer 2 | Type | Source IP | Dest IP | Auth |
+|--------|--------|------|-----------|---------|------|
+| SRX1 (65001) | SRX2 (65002) | eBGP | 10.0.12.1 | 10.0.12.2 | MD5 `<BGP-PASSWORD-HERE>` |
+| SRX1 (65001) | R1 (65003) | eBGP | 10.0.13.1 | 10.0.13.2 | MD5 `<BGP-PASSWORD-HERE>` |
+| SRX2 (65002) | R1 (65003) | eBGP | 10.0.23.1 | 10.0.23.2 | MD5 `<BGP-PASSWORD-HERE>` |
+
+---
+
+## Équipements simulés / Simulated Equipment
+
+| Équipement | Image EVE-NG / GNS3 | vCPU | vRAM | Notes |
+|------------|---------------------|------|------|-------|
+| SRX1 | Juniper vSRX 21.4R1 | 2 | 4 GB | vSRX in packet mode (routing only) |
+| SRX2 | Juniper vSRX 21.4R1 | 2 | 4 GB | vSRX in packet mode |
+| R1-Cisco | Cisco IOSv 15.9 ou IOS-XE | 1 | 512 MB | GNS3 : IOSvL2 ou CSR1000v |
+
+---
+
+## Préfixes annoncés par BGP / BGP Advertised Prefixes
+
+Chaque routeur annonce uniquement son loopback via BGP :
+
+| Routeur | Préfixe annoncé | Visible sur |
+|---------|----------------|-------------|
+| SRX1 | `10.255.1.1/32` | SRX2, R1 |
+| SRX2 | `10.255.2.1/32` | SRX1, R1 |
+| R1 | `10.255.3.1/32` | SRX1, SRX2 |
+
+---
+
+## Notes d'installation / Setup Notes
+
+1. Démarrer les trois VMs dans l'ordre : SRX1 → SRX2 → R1
+2. JunOS nécessite ~3 minutes de boot — attendre l'invite `login:`
+3. Connexion console JunOS : login `root`, puis `cli` pour l'interface opérationnelle
+4. Commencer par vérifier les interfaces avant de configurer BGP : `show interfaces terse`

--- a/labs/routing/juniper-junos-basics/verification.md
+++ b/labs/routing/juniper-junos-basics/verification.md
@@ -1,0 +1,230 @@
+# Verification — Juniper JunOS Lab
+
+Commandes de vérification post-configuration avec output attendu.
+Post-configuration verification commands with expected output.
+
+> Exécuter ces commandes en mode opérationnel JunOS (prompt `>`)
+
+---
+
+## 1. Vérification des interfaces / Interface Verification
+
+### `show interfaces terse`
+
+```
+user@SRX1> show interfaces terse
+Interface               Admin Link Proto    Local                 Remote
+ge-0/0/0                up    up
+ge-0/0/0.0              up    up   inet     10.0.12.1/30
+ge-0/0/1                up    up
+ge-0/0/1.0              up    up   inet     10.0.13.1/30
+lo0                     up    up
+lo0.0                   up    up   inet     10.255.1.1/32    --> 0/0
+```
+
+> Tous les statuts doivent être `up up`. `lo0.0` remote `0/0` est normal pour un loopback.
+
+### `show interfaces ge-0/0/0 detail` (extrait)
+
+```
+user@SRX1> show interfaces ge-0/0/0 detail
+Physical interface: ge-0/0/0, Enabled, Physical link is Up
+  Description: Link to SRX2 ge-0/0/0 (AS65002) — 10.0.12.0/30
+  ...
+  Input errors:
+    Errors: 0, Drops: 0, Framing errors: 0, ...
+  Output errors:
+    Carrier transitions: 1, Errors: 0, Drops: 0, ...
+  Logical interface ge-0/0/0.0
+    Flags: Up SNMP-Traps
+    Protocol inet, MTU: 1500
+      Flags: None
+      Addresses, Flags: Is-Preferred Is-Primary
+        Destination: 10.0.12.0/30, Local: 10.0.12.1, Broadcast: 10.0.12.3
+```
+
+---
+
+## 2. Vérification BGP / BGP Verification
+
+### `show bgp summary`
+
+```
+user@SRX1> show bgp summary
+Threading mode: BGP I/O
+Groups: 2 Peers: 2 Down peers: 0
+Table          Tot Paths  Act Paths Suppressed    History Damp State    Pending
+inet.0
+                       2          2          0          0          0          0
+Peer                     AS      InPkt     OutPkt    OutQ   Flaps Last Up/Dwn State|#Active/Received/Accepted/Damped...
+10.0.12.2             65002        148        147       0       0       58:12 2/2/2/0              0/0/0/0
+10.0.13.2             65003        132        135       0       0       55:30 1/1/1/0              0/0/0/0
+```
+
+> Résultat attendu :
+> - `Down peers: 0` — aucun voisin en état DOWN
+> - Tous les voisins ont un `State` de type `X/X/X/0` (actif/reçu/accepté/damped)
+> - `Flaps: 0` ou très faible — voisins stables
+> - `Last Up/Dwn` montre le temps depuis le dernier changement d'état
+
+### `show bgp neighbor 10.0.12.2`
+
+```
+user@SRX1> show bgp neighbor 10.0.12.2
+Peer: 10.0.12.2+51234 AS 65002 Local: 10.0.12.1+179 AS 65001
+  Description: SRX2 (AS65002) — connected on ge-0/0/0
+  Type: External    State: Established    Flags: <Sync>
+  Last State: OpenConfirm   Last Event: RecvKeepAlive
+  Last Error: None
+  Options: <Preference LogUpDown GracefulShutdownRcv>
+  Options: <Authentication>
+  Authentication key is configured
+  Holdtime: 90 Preference: 170+0
+  Number of flaps: 0
+  Peer ID: 10.255.2.1     Local ID: 10.255.1.1    Active Holdtime: 90
+  Keepalive Interval: 30          Peer index: 0   AIGP originator: N/A
+  ...
+  Import: IMPORT-EBGP        Export: EXPORT-LOOPBACK
+  ...
+  BGP Output Queue[0]: 0
+  Flap Statistics:
+    Total: 0
+    Last flap event: Opened
+  Input messages:  Total 148  Updates 2  Refreshes 0  Octets 2828
+  Output messages: Total 147  Updates 1  Refreshes 0  Octets 2807
+  Output Queue[0]: 0
+```
+
+> Points clés à vérifier :
+> - `State: Established` — session active
+> - `Authentication key is configured` — MD5 en place
+> - `Number of flaps: 0` — session stable
+> - `Import: IMPORT-EBGP  Export: EXPORT-LOOPBACK` — politiques appliquées
+
+### `show route protocol bgp`
+
+```
+user@SRX1> show route protocol bgp
+
+inet.0: 7 destinations, 7 routes (7 active, 0 holddown, 0 hidden)
++ = Active Route, - = Last Active, * = Both
+
+10.255.2.1/32      *[BGP/170] 00:58:12, localpref 100
+                    AS path: 65002 I, validation-state: unverified
+                  > to 10.0.12.2 via ge-0/0/0.0
+10.255.3.1/32      *[BGP/170] 00:55:30, localpref 100
+                    AS path: 65003 I, validation-state: unverified
+                  > to 10.0.13.2 via ge-0/0/1.0
+```
+
+> Résultat attendu :
+> - SRX1 voit `10.255.2.1/32` (loopback SRX2) appris via `10.0.12.2`
+> - SRX1 voit `10.255.3.1/32` (loopback R1) appris via `10.0.13.2`
+> - `localpref 100` confirmé — policy IMPORT-EBGP correctement appliquée
+
+### `show route advertising-protocol bgp 10.0.12.2`
+
+```
+user@SRX1> show route advertising-protocol bgp 10.0.12.2
+
+inet.0: 7 destinations, 7 routes (7 active, 0 holddown, 0 hidden)
+  Prefix                  Nexthop              MED     Lclpref    AS path
+* 10.255.1.1/32           Self                                    I
+```
+
+> Résultat attendu : SRX1 annonce uniquement son loopback `/32` vers SRX2 — policy EXPORT-LOOPBACK correcte.
+
+---
+
+## 3. Vérification de la connectivité / Connectivity Check
+
+### Ping entre loopbacks
+
+```
+user@SRX1> ping 10.255.2.1 source 10.255.1.1 count 5
+PING 10.255.2.1 (10.255.2.1): 56 data bytes
+64 bytes from 10.255.2.1: icmp_seq=0 ttl=64 time=1.432 ms
+64 bytes from 10.255.2.1: icmp_seq=1 ttl=64 time=1.218 ms
+64 bytes from 10.255.2.1: icmp_seq=2 ttl=64 time=1.344 ms
+64 bytes from 10.255.2.1: icmp_seq=3 ttl=64 time=1.190 ms
+64 bytes from 10.255.2.1: icmp_seq=4 ttl=64 time=1.277 ms
+
+--- 10.255.2.1 ping statistics ---
+5 packets transmitted, 5 packets received, 0% packet loss
+round-trip min/avg/max/stddev = 1.190/1.292/1.432/0.083 ms
+```
+
+> Source explicite `10.255.1.1` pour tester le chemin BGP complet (loopback-to-loopback).
+
+### Traceroute vers loopback R1
+
+```
+user@SRX1> traceroute 10.255.3.1 source 10.255.1.1
+traceroute to 10.255.3.1 (10.255.3.1), 30 hops max, 52 byte packets
+ 1  10.0.13.2 (10.0.13.2)  1.523 ms  1.387 ms  1.456 ms
+```
+
+---
+
+## 4. Vérification des filtres / Firewall Filter Verification
+
+### `show firewall filter PROTECT-RE`
+
+```
+user@SRX1> show firewall filter PROTECT-RE
+
+Filter: PROTECT-RE
+Counters:
+Name                                                Bytes              Packets
+DENY-ALL-COUNT                                          0                    0
+```
+
+> `DENY-ALL-COUNT = 0` signifie qu'aucun paquet n'a été bloqué — état nominal.
+> Si ce compteur monte, vérifier quel trafic est rejeté avec `show firewall log`.
+
+### `show firewall log`
+
+```
+user@SRX1> show firewall log
+Log :
+Time      Filter    Action Interface     Protocol Src Addr        Dest Addr
+00:00:00  PROTECT-RE D     ge-0/0/0.0    TCP      <attacker-IP>   10.255.1.1
+```
+
+> Affiche les paquets bloqués avec log activé.
+
+---
+
+## 5. Vérification commit / Commit Verification
+
+### `show system commit`
+
+```
+user@SRX1> show system commit
+0   2026-04-15 10:23:45 UTC by admin via cli
+1   2026-04-15 09:50:12 UTC by admin via cli
+2   2026-04-15 09:30:05 UTC by admin via cli
+```
+
+### Comparer deux versions
+
+```
+user@SRX1> show system rollback compare 0 1
+[edit protocols bgp group EBGP-TO-SRX2 neighbor 10.0.12.2]
++      description "SRX2 (AS65002) — connected on ge-0/0/0";
+```
+
+---
+
+## 6. Récapitulatif de validation / Validation Checklist
+
+| Vérification | Commande | Résultat attendu |
+|--------------|----------|-----------------|
+| Interfaces up | `show interfaces terse` | Tous `up up` |
+| Sessions BGP up | `show bgp summary` | `Down peers: 0`, State Established |
+| Routes BGP reçues | `show route protocol bgp` | 2 loopbacks /32 dans inet.0 |
+| Export policy OK | `show route advertising-protocol bgp X.X.X.X` | Uniquement le loopback propre |
+| Auth MD5 active | `show bgp neighbor X.X.X.X` | `Authentication key is configured` |
+| Aucun filtre bloquant | `show firewall filter PROTECT-RE` | `DENY-ALL-COUNT = 0` |
+| Ping loopback-to-loopback | `ping 10.255.2.1 source 10.255.1.1` | 0% loss |
+| Ping vers R1 | `ping 10.255.3.1 source 10.255.1.1` | 0% loss |

--- a/labs/routing/mpls-traffic-engineering/README.md
+++ b/labs/routing/mpls-traffic-engineering/README.md
@@ -1,0 +1,88 @@
+# Lab — MPLS Traffic Engineering (RSVP-TE)
+
+## Objectif / Objective
+
+**FR** — Mettre en oeuvre MPLS Traffic Engineering (MPLS-TE) avec RSVP comme protocole de signalisation sur un réseau Cisco IOS-XE. Le lab couvre la création de tunnels TE avec chemins explicites, la réservation de bande passante, le Fast Reroute (FRR) pour la protection des liens, et la comparaison avec LDP.
+
+**EN** — Implement MPLS Traffic Engineering (MPLS-TE) using RSVP as signaling protocol on Cisco IOS-XE. The lab covers TE tunnel creation with explicit paths, bandwidth reservation, Fast Reroute (FRR) for link protection, and comparison with LDP.
+
+---
+
+## LDP vs RSVP-TE
+
+| Aspect | LDP | RSVP-TE |
+|--------|-----|---------|
+| **Objectif** | Distribution d'étiquettes hop-by-hop | Ingénierie du trafic : chemins contraints |
+| **Chemin** | Meilleur chemin IGP (OSPF/ISIS) | Chemin explicite ou calculé sous contraintes |
+| **Réservation BW** | Aucune | Réservation de bande passante RSVP |
+| **Redondance** | Convergence IGP (secondes) | Fast Reroute : < 50 ms |
+| **Complexité** | Simple | Élevée (TE extensions, CSPF, RSVP) |
+| **Cas d'usage** | VPN L3, routage MPLS basique | QoS critique, redondance < 50 ms, charge balancing |
+| **Protocole** | LDP (UDP/TCP 646) | RSVP-TE (IP proto 46) |
+| **Extensions IGP** | Aucune | OSPF-TE ou ISIS-TE obligatoires |
+
+---
+
+## Cas d'usage / Use Cases
+
+- **QoS et priorisation** : Forcer un flux critique (voix, SCADA) sur un chemin avec BW réservé, indépendamment de la décision IGP
+- **Redondance < 50 ms** : FRR protège un lien ou noeud défaillant — basculement sub-secondaire sans attendre OSPF
+- **Load balancing** : Distribuer le trafic sur plusieurs tunnels TE (Equal/Unequal cost)
+- **Backbone opérateur** : Technologie utilisée chez les opérateurs pour les VPN MPLS L3 avec SLA garanti
+
+---
+
+## Topologie / Topology
+
+Voir [topology.md](topology.md)
+
+```
+PE1 (1.1.1.1) ──[Gi0/0]── P (2.2.2.2) ──[Gi0/1]── PE2 (3.3.3.3)
+      \                                                   /
+       \──[Gi0/1]──── Lien direct (bypass FRR) ─────[Gi0/1]
+```
+
+---
+
+## Statut / Status
+
+🚧 En cours de construction
+
+---
+
+## Technologies utilisées / Technologies Used
+
+| Technologie | Rôle |
+|-------------|------|
+| Cisco IOS-XE | Plateforme PE et P |
+| MPLS (LDP + RSVP-TE) | Commutation d'étiquettes et TE |
+| OSPF avec extensions TE | IGP avec diffusion des capacités TE |
+| RSVP-TE (RFC 3209) | Signalisation et réservation de ressources |
+| CSPF (Constraint-based SPF) | Calcul des chemins TE sous contraintes |
+| Fast Reroute (RFC 4090) | Protection < 50 ms des liens MPLS |
+| EVE-NG / GNS3 | Environnement de simulation réseau |
+
+---
+
+## Fichiers du lab / Lab Files
+
+| Fichier | Description |
+|---------|-------------|
+| [topology.md](topology.md) | Plan d'adressage, schéma, tunnels TE |
+| [configs/PE1-TE.ios](configs/PE1-TE.ios) | Config PE1 — ingress tunnel TE + FRR |
+| [configs/P-TE.ios](configs/P-TE.ios) | Config P — transit + bypass tunnel FRR |
+| [configs/PE2-TE.ios](configs/PE2-TE.ios) | Config PE2 — egress tunnel TE |
+| [verification.md](verification.md) | Commandes `show` avec output attendu |
+
+---
+
+## Concepts couverts / Concepts Covered
+
+- OSPF TE extensions : `mpls traffic-eng area`, annonce des capacités de liens
+- RSVP : messages PATH/RESV, réservation de bande passante
+- Tunnel MPLS-TE : `interface Tunnel`, `tunnel mpls traffic-eng`
+- Chemins explicites : `ip explicit-path`
+- `autoroute announce` : intégration du tunnel dans la table de routage
+- Fast Reroute : tunnel bypass, `tunnel mpls traffic-eng fast-reroute`
+- `affinity` et `attribute-flags` : contraintes sur les liens
+- Débogage : `debug mpls traffic-eng`, `show rsvp`

--- a/labs/routing/mpls-traffic-engineering/configs/P-TE.ios
+++ b/labs/routing/mpls-traffic-engineering/configs/P-TE.ios
@@ -1,0 +1,86 @@
+! ============================================================
+! Cisco IOS-XE Configuration — P (MPLS-TE Transit / Core)
+! Hostname   : P
+! Loopback   : 2.2.2.2/32
+! Gi0/0      : 10.0.12.2/30 — Link to PE1
+! Gi0/1      : 10.0.23.1/30 — Link to PE2
+!
+! Role: MPLS-TE transit P-router
+!   - Forwards labeled packets (does NOT initiate or terminate tunnels)
+!   - Participates in OSPF TE to advertise link bandwidth
+!   - Acts as RSVP transit node (PATH/RESV messages pass through)
+!   - FRR: can host a bypass tunnel protecting its own upstream link
+! ============================================================
+
+hostname P
+!
+! ── INTERFACES ─────────────────────────────────────────────
+interface Loopback0
+ description P Router-ID
+ ip address 2.2.2.2 255.255.255.255
+ no shutdown
+!
+interface GigabitEthernet0/0
+ description Link to PE1 — 10.0.12.0/30
+ ip address 10.0.12.2 255.255.255.252
+ !
+ ! MPLS forwarding: label imposition/disposition for transit traffic
+ mpls ip
+ !
+ ! RSVP bandwidth allocation — same as PE1 side
+ ip rsvp bandwidth 750000                       ! 750 Mbps reservable
+ !
+ ! Announce link capabilities via OSPF-TE
+ mpls traffic-eng tunnels
+ !
+ no shutdown
+!
+interface GigabitEthernet0/1
+ description Link to PE2 — 10.0.23.0/30
+ ip address 10.0.23.1 255.255.255.252
+ mpls ip
+ ip rsvp bandwidth 750000
+ mpls traffic-eng tunnels
+ no shutdown
+!
+! ── IGP — OSPF WITH TE EXTENSIONS ─────────────────────────
+! The P router must participate in OSPF-TE to:
+!   1. Advertise its own links' TE capabilities (BW, affinity)
+!   2. Allow CSPF on PE1 to calculate TE paths through P
+!
+router ospf 1
+ router-id 2.2.2.2
+ mpls traffic-eng router-id Loopback0
+ mpls traffic-eng area 0
+ !
+ network 2.2.2.2 0.0.0.0 area 0
+ network 10.0.12.0 0.0.0.3 area 0
+ network 10.0.23.0 0.0.0.3 area 0
+!
+! ── MPLS ──────────────────────────────────────────────────
+mpls traffic-eng tunnels
+mpls ldp router-id Loopback0 force
+!
+! ── RSVP ──────────────────────────────────────────────────
+! P does not initiate RSVP sessions — it only forwards PATH/RESV messages.
+! RSVP bandwidth is configured per-interface (see above).
+! Hellos for FRR: allows P to detect failure of its neighbors quickly.
+!
+ip rsvp signalling hello
+ip rsvp signalling hello refresh misses 4
+!
+! ── NOTE: FRR BYPASS TUNNEL ON P ──────────────────────────
+! In a more complex topology with multiple P routers, this P node
+! could also host a bypass tunnel to protect one of its links.
+! Example (not active in this lab):
+!
+! interface Tunnel10
+!  description Bypass — protect P-to-PE2 link (Gi0/1)
+!  tunnel mode mpls traffic-eng
+!  tunnel source Loopback0
+!  tunnel destination 3.3.3.3
+!  tunnel mpls traffic-eng bandwidth 100000
+!  tunnel mpls traffic-eng path-option 1 dynamic
+!  tunnel mpls traffic-eng fast-reroute protect-from 10.0.23.0/30
+!
+end

--- a/labs/routing/mpls-traffic-engineering/configs/PE1-TE.ios
+++ b/labs/routing/mpls-traffic-engineering/configs/PE1-TE.ios
@@ -1,0 +1,143 @@
+! ============================================================
+! Cisco IOS-XE Configuration — PE1 (MPLS-TE Ingress)
+! Hostname   : PE1
+! Loopback   : 1.1.1.1/32
+! Gi0/0      : 10.0.12.1/30 — Link to P (primary path)
+! Gi0/1      : 10.0.13.1/30 — Link to PE2 (bypass/FRR path)
+!
+! Role: MPLS-TE ingress PE — head-end of TE tunnels
+! Tunnel0    : Primary TE tunnel to PE2 (via P) — 100 Mbps reserved
+! Tunnel1    : Bypass tunnel to PE2 (direct, FRR) — 50 Mbps reserved
+! ============================================================
+
+hostname PE1
+!
+! ── INTERFACES ─────────────────────────────────────────────
+interface Loopback0
+ description PE1 Router-ID — MPLS-TE tunnel source
+ ip address 1.1.1.1 255.255.255.255
+ no shutdown
+!
+interface GigabitEthernet0/0
+ description Link to P (primary path) — 10.0.12.0/30
+ ip address 10.0.12.1 255.255.255.252
+ !
+ ! Enable MPLS on the interface
+ mpls ip
+ !
+ ! Enable RSVP with bandwidth reservation
+ ! Reserve 75% of interface BW for TE (750 Mbps of 1 Gbps)
+ ip rsvp bandwidth 750000                       ! kbps — 750 Mbps total reservable
+ !
+ ! Enable MPLS TE on the interface — announces TE capabilities via OSPF
+ mpls traffic-eng tunnels
+ !
+ no shutdown
+!
+interface GigabitEthernet0/1
+ description Link to PE2 direct (bypass/FRR path) — 10.0.13.0/30
+ ip address 10.0.13.1 255.255.255.252
+ mpls ip
+ ip rsvp bandwidth 750000
+ mpls traffic-eng tunnels
+ no shutdown
+!
+! ── TUNNEL INTERFACES ─────────────────────────────────────
+!
+! PRIMARY TE TUNNEL: PE1 → P → PE2
+! Uses explicit path through P (2.2.2.2) — does NOT follow IGP shortest path
+!
+interface Tunnel0
+ description Primary MPLS-TE tunnel to PE2 via P
+ !
+ ! Tunnel mode: MPLS traffic-eng (RSVP-TE signaling)
+ tunnel mode mpls traffic-eng
+ !
+ ! Source: PE1 Loopback (router-id)
+ tunnel source Loopback0
+ !
+ ! Destination: PE2 Loopback (egress PE router-id)
+ tunnel destination 3.3.3.3
+ !
+ ! Bandwidth reservation: RSVP will reserve 100 Mbps along the path
+ tunnel mpls traffic-eng bandwidth 100000       ! kbps = 100 Mbps
+ !
+ ! Path options (tried in order — lower number = higher preference):
+ !   Option 1: explicit path via P (deterministic)
+ !   Option 2: dynamic (CSPF finds best path if explicit fails)
+ tunnel mpls traffic-eng path-option 1 explicit name PRIMARY-PATH
+ tunnel mpls traffic-eng path-option 2 dynamic
+ !
+ ! Autoroute: inject this tunnel into the IGP routing table
+ ! Traffic for PE2 (3.3.3.3) will use this tunnel instead of IGP path
+ tunnel mpls traffic-eng autoroute announce
+ !
+ ! Fast Reroute: enable FRR on this tunnel
+ ! If protected link/node fails, traffic shifts to bypass tunnel in < 50 ms
+ tunnel mpls traffic-eng fast-reroute
+ !
+ ! Priority: setup priority 7 (low), hold priority 0 (high)
+ ! Hold priority 0 = this tunnel will NOT be preempted by new tunnels
+ tunnel mpls traffic-eng priority 7 0
+ !
+ no shutdown
+!
+! BYPASS TUNNEL: PE1 → PE2 direct (FRR protection path)
+! This tunnel protects the PE1-P link and the P node.
+! It is used by FRR when the primary path (via P) fails.
+!
+interface Tunnel1
+ description FRR bypass tunnel to PE2 (direct link — avoids P)
+ tunnel mode mpls traffic-eng
+ tunnel source Loopback0
+ tunnel destination 3.3.3.3
+ tunnel mpls traffic-eng bandwidth 50000        ! Reserve 50 Mbps for bypass
+ tunnel mpls traffic-eng path-option 1 explicit name BYPASS-PATH
+ !
+ ! Mark this tunnel as a bypass tunnel
+ ! It will protect the link PE1-P (interface Gi0/0 toward 2.2.2.2)
+ tunnel mpls traffic-eng fast-reroute protect-from 10.0.12.0/30
+ !
+ ! Lower priority than primary — bypass only used during failure
+ tunnel mpls traffic-eng priority 1 1
+ !
+ no shutdown
+!
+! ── IGP — OSPF WITH TE EXTENSIONS ─────────────────────────
+router ospf 1
+ router-id 1.1.1.1
+ !
+ ! Enable MPLS TE extensions in OSPF
+ ! This allows OSPF to flood TE link attributes (BW, affinity) via LSA type 10
+ mpls traffic-eng router-id Loopback0
+ mpls traffic-eng area 0
+ !
+ network 1.1.1.1 0.0.0.0 area 0                ! Loopback
+ network 10.0.12.0 0.0.0.3 area 0              ! Link to P
+ network 10.0.13.0 0.0.0.3 area 0              ! Link to PE2 (bypass)
+!
+! ── MPLS ──────────────────────────────────────────────────
+mpls traffic-eng tunnels
+mpls ldp router-id Loopback0 force
+!
+! ── EXPLICIT PATHS ─────────────────────────────────────────
+! Explicit paths define the strict hop sequence for TE tunnels.
+! 'strict' = must go through this exact hop (no IGP deviation)
+! 'loose' = must reach this hop but intermediate hops are free
+!
+! Primary path: PE1 → P (2.2.2.2) → PE2 (3.3.3.3)
+ip explicit-path name PRIMARY-PATH enable
+ next-address strict 10.0.12.2                 ! P's interface toward PE1
+ next-address strict 10.0.23.2                 ! PE2's interface toward P
+!
+! Bypass path: PE1 → PE2 direct (avoids P entirely)
+ip explicit-path name BYPASS-PATH enable
+ next-address strict 10.0.13.2                 ! PE2's interface on direct link
+!
+! ── RSVP ──────────────────────────────────────────────────
+! RSVP is enabled per-interface (ip rsvp bandwidth above).
+! Global RSVP parameters:
+ip rsvp signalling hello                        ! Enable RSVP hellos for FRR detection
+ip rsvp signalling hello refresh misses 4
+!
+end

--- a/labs/routing/mpls-traffic-engineering/configs/PE2-TE.ios
+++ b/labs/routing/mpls-traffic-engineering/configs/PE2-TE.ios
@@ -1,0 +1,82 @@
+! ============================================================
+! Cisco IOS-XE Configuration — PE2 (MPLS-TE Egress)
+! Hostname   : PE2
+! Loopback   : 3.3.3.3/32
+! Gi0/0      : 10.0.23.2/30 — Link to P (primary path)
+! Gi0/1      : 10.0.13.2/30 — Link to PE1 (bypass/FRR path)
+!
+! Role: MPLS-TE egress PE — tail-end of TE tunnels from PE1
+!   - Terminates MPLS-TE tunnels (label disposition)
+!   - Participates in OSPF TE to advertise link BW
+!   - Does NOT initiate tunnels in this lab (unidirectional)
+!   - For bidirectional TE, a symmetric Tunnel would be configured here
+! ============================================================
+
+hostname PE2
+!
+! ── INTERFACES ─────────────────────────────────────────────
+interface Loopback0
+ description PE2 Router-ID — MPLS-TE tunnel destination
+ ip address 3.3.3.3 255.255.255.255
+ no shutdown
+!
+interface GigabitEthernet0/0
+ description Link to P — 10.0.23.0/30 (primary path arrival)
+ ip address 10.0.23.2 255.255.255.252
+ mpls ip
+ ip rsvp bandwidth 750000
+ mpls traffic-eng tunnels
+ no shutdown
+!
+interface GigabitEthernet0/1
+ description Link to PE1 direct — 10.0.13.0/30 (bypass/FRR path arrival)
+ ip address 10.0.13.2 255.255.255.252
+ mpls ip
+ ip rsvp bandwidth 750000
+ mpls traffic-eng tunnels
+ no shutdown
+!
+! ── IGP — OSPF WITH TE EXTENSIONS ─────────────────────────
+router ospf 1
+ router-id 3.3.3.3
+ mpls traffic-eng router-id Loopback0
+ mpls traffic-eng area 0
+ !
+ network 3.3.3.3 0.0.0.0 area 0
+ network 10.0.23.0 0.0.0.3 area 0
+ network 10.0.13.0 0.0.0.3 area 0
+!
+! ── MPLS ──────────────────────────────────────────────────
+mpls traffic-eng tunnels
+mpls ldp router-id Loopback0 force
+!
+! ── RSVP ──────────────────────────────────────────────────
+ip rsvp signalling hello
+ip rsvp signalling hello refresh misses 4
+!
+! ── NOTE: BIDIRECTIONAL TE ────────────────────────────────
+! In production, PE2 should also have a return tunnel toward PE1.
+! This ensures symmetric path engineering for traffic in both directions.
+! Example mirror configuration for PE2 → PE1:
+!
+! ip explicit-path name PE2-TO-PE1-PRIMARY enable
+!  next-address strict 10.0.23.1               ! P's interface toward PE2
+!  next-address strict 10.0.12.1               ! PE1's interface toward P
+!
+! ip explicit-path name PE2-TO-PE1-BYPASS enable
+!  next-address strict 10.0.13.1               ! PE1's interface on direct link
+!
+! interface Tunnel10
+!  description Primary MPLS-TE tunnel from PE2 to PE1
+!  tunnel mode mpls traffic-eng
+!  tunnel source Loopback0
+!  tunnel destination 1.1.1.1
+!  tunnel mpls traffic-eng bandwidth 100000
+!  tunnel mpls traffic-eng path-option 1 explicit name PE2-TO-PE1-PRIMARY
+!  tunnel mpls traffic-eng path-option 2 dynamic
+!  tunnel mpls traffic-eng autoroute announce
+!  tunnel mpls traffic-eng fast-reroute
+!  tunnel mpls traffic-eng priority 7 0
+!  no shutdown
+!
+end

--- a/labs/routing/mpls-traffic-engineering/topology.md
+++ b/labs/routing/mpls-traffic-engineering/topology.md
@@ -1,0 +1,110 @@
+# Topology — MPLS Traffic Engineering Lab
+
+## Schéma logique / Logical Diagram
+
+```
+           Primary TE tunnel (TE-TUNNEL-TO-PE2)
+           ┌─────────────────────────────────────────►
+           │
+PE1 ─────[Gi0/0]──── P ────[Gi0/1]──── PE2
+1.1.1.1                2.2.2.2          3.3.3.3
+   \                                      /
+    \──[Gi0/1]────────────────[Gi0/1]───/
+           Bypass tunnel (FRR path)
+           (protège le lien PE1-P et le noeud P)
+
+Légende :
+  ─── : lien physique GigabitEthernet (1 Gbps)
+  ───► : tunnel MPLS-TE (label-switched path)
+```
+
+---
+
+## Plan d'adressage / Addressing Plan
+
+### Loopbacks (Router-ID & tunnel endpoints)
+
+| Équipement | Interface | Adresse IP | Rôle |
+|------------|-----------|-----------|------|
+| PE1 | Loopback0 | `1.1.1.1/32` | Ingress PE — tête de tunnel TE |
+| P | Loopback0 | `2.2.2.2/32` | P-router transit |
+| PE2 | Loopback0 | `3.3.3.3/32` | Egress PE — destination tunnel TE |
+
+### Liens point-à-point / Point-to-Point Links
+
+| Lien | Réseau | Adresses | Interfaces |
+|------|--------|---------|------------|
+| PE1 ↔ P | `10.0.12.0/30` | PE1: `10.0.12.1` — P: `10.0.12.2` | PE1: Gi0/0 — P: Gi0/0 |
+| P ↔ PE2 | `10.0.23.0/30` | P: `10.0.23.1` — PE2: `10.0.23.2` | P: Gi0/1 — PE2: Gi0/0 |
+| PE1 ↔ PE2 | `10.0.13.0/30` | PE1: `10.0.13.1` — PE2: `10.0.13.2` | PE1: Gi0/1 — PE2: Gi0/1 |
+
+---
+
+## Tunnels MPLS-TE
+
+### Tunnel principal / Primary Tunnel
+
+| Paramètre | Valeur |
+|-----------|--------|
+| Nom | `Tunnel0` (sur PE1) |
+| Source | `1.1.1.1` (Loopback0 PE1) |
+| Destination | `3.3.3.3` (Loopback0 PE2) |
+| Chemin explicite | `PRIMARY-PATH` : PE1 → P (2.2.2.2) → PE2 |
+| Bande passante réservée | 100 Mbps |
+| Path option | 1 — explicit-path `PRIMARY-PATH` |
+| Path option (backup) | 2 — dynamic (CSPF) |
+| Autoroute announce | Activé — intégration dans table de routage PE1 |
+| Fast Reroute | Activé |
+
+### Tunnel bypass FRR / FRR Bypass Tunnel
+
+| Paramètre | Valeur |
+|-----------|--------|
+| Nom | `Tunnel1` (sur PE1) |
+| Source | `1.1.1.1` (Loopback0 PE1) |
+| Destination | `3.3.3.3` (Loopback0 PE2) |
+| Chemin | `BYPASS-PATH` : PE1 → PE2 direct (lien Gi0/1) |
+| Type | Bypass tunnel — protège le lien PE1-P et le noeud P |
+| Bande passante | 50 Mbps |
+
+---
+
+## OSPF avec extensions TE
+
+| Paramètre | Valeur |
+|-----------|--------|
+| Protocole IGP | OSPF Process 1 |
+| Area | Area 0 (backbone) |
+| TE extensions | `mpls traffic-eng area 0` sur tous les routeurs |
+| Router-ID | Loopback0 de chaque équipement |
+
+### Capacités des liens / Link Bandwidth Allocation
+
+| Lien | BW totale | BW allouable (75%) | BW réservée tunnel principal |
+|------|-----------|--------------------|------------------------------|
+| PE1 — P (Gi0/0) | 1000 Mbps | 750 Mbps | 100 Mbps |
+| P — PE2 (Gi0/1) | 1000 Mbps | 750 Mbps | 100 Mbps |
+| PE1 — PE2 (Gi0/1) | 1000 Mbps | 750 Mbps | 50 Mbps (bypass) |
+
+---
+
+## Comparaison avec la topologie mpls-l3vpn
+
+Ce lab enrichit la topologie [mpls-l3vpn](../mpls-l3vpn/README.md) en ajoutant :
+
+| Ajout | Description |
+|-------|-------------|
+| RSVP-TE | Remplacement de la signalisation LDP par RSVP-TE sur les PE |
+| Chemins explicites | Les tunnels TE suivent des chemins déterministes, pas le meilleur IGP |
+| Réservation de BW | `ip rsvp bandwidth` sur chaque interface |
+| FRR | Protection < 50 ms en cas de défaillance d'un lien ou noeud |
+| `autoroute announce` | Les VRF L3VPN empruntent les tunnels TE automatiquement |
+
+---
+
+## Notes d'installation / Setup Notes
+
+1. Configurer OSPF + TE extensions **avant** RSVP et les tunnels
+2. Vérifier `show mpls traffic-eng topology` avant de créer les tunnels
+3. Les tunnels TE ne montent que si RSVP est opérationnel sur tous les liens du chemin
+4. `commit` sur le chemin explicite avec `no shutdown` sur le tunnel pour déclencher la signalisation RSVP

--- a/labs/routing/mpls-traffic-engineering/verification.md
+++ b/labs/routing/mpls-traffic-engineering/verification.md
@@ -1,0 +1,239 @@
+# Verification — MPLS Traffic Engineering Lab
+
+Commandes de vérification post-configuration avec output attendu.
+Run on PE1 (ingress) unless otherwise specified.
+
+---
+
+## 1. Vérification OSPF TE / OSPF TE Verification
+
+### `show mpls traffic-eng topology`
+
+```
+PE1# show mpls traffic-eng topology
+
+My_System_id: 1.1.1.1 (OSPF 1 area 0)
+...
+  Link[0]: Point-to-Point, Nbr Node id 2, gen 6
+    Frag id 0, Intf Address: 10.0.12.1, Nbr Intf Address: 10.0.12.2
+    TE Metric: 1, IGP Metric: 1, Attribute Flags: 0x0
+    Attribute Names:
+    Physical BW: 1000000 kbits/sec, Max Reservable BW Global: 750000 kbits/sec
+    Max Reservable BW Sub: 750000 kbits/sec
+      [ 0] Reservable Global BW:  650000 kbits/sec (after 100000 reserved)
+      [ 1] Reservable Global BW:  750000 kbits/sec
+      ...
+  Link[1]: Point-to-Point, Nbr Node id 3, gen 5
+    Frag id 0, Intf Address: 10.0.13.1, Nbr Intf Address: 10.0.13.2
+    TE Metric: 1, IGP Metric: 1, Attribute Flags: 0x0
+    Physical BW: 1000000 kbits/sec, Max Reservable BW Global: 750000 kbits/sec
+    ...
+```
+
+> Vérifier que tous les liens apparaissent avec leur BW physique et réservable.
+> `Max Reservable BW Global: 750000` confirme que `ip rsvp bandwidth 750000` est actif.
+
+---
+
+## 2. Vérification des tunnels TE / TE Tunnel Verification
+
+### `show mpls traffic-eng tunnels`
+
+```
+PE1# show mpls traffic-eng tunnels
+
+Name:PE1_t0                          (Tunnel0) Destination: 3.3.3.3
+  Status:
+    Admin: up         Oper: up     Path: valid       Signalling: connected
+    path option 1, type explicit PRIMARY-PATH (Basis for Setup, path weight 2)
+  Config Parameters:
+    Bandwidth: 100000      kbps (Global)  Priority: 7  0   Affinity: 0x0/0xFFFF
+    Metric Type: TE (default)
+    AutoRoute: enabled  LockDown: disabled  Loadshare: 100  bw-based
+    auto-bw: disabled
+  Active Path Option Parameters:
+    State: explicit path option 1 is active
+    BandwidthOverride: disabled  LockDown: disabled  Verbatim: disabled
+  InLabel  :  -
+  OutLabel : GigabitEthernet0/0, 18
+  RSVP Signalling Info:
+       Src 1.1.1.1, Dst 3.3.3.3, Tun_Id 0, Tun_Instance 37
+       RSVP Path Info:
+         My Address: 10.0.12.1
+         Explicit Route: 10.0.12.2 10.0.23.2 3.3.3.3
+         Record   Route:  NONE
+         Tspec: ave rate=100000 kbits, burst=1000 bytes, peak rate=100000 kbits
+       RSVP Resv Info:
+         Record   Route:  NONE
+         Fspec: ave rate=100000 kbits, burst=1000 bytes, peak rate=100000 kbits
+  Shortest Unconstrained Path Info:
+    Path Weight: 2 (TE)
+    Explicit Route: 10.0.12.2 3.3.3.3
+
+Name:PE1_t1                          (Tunnel1) Destination: 3.3.3.3
+  Status:
+    Admin: up         Oper: up     Path: valid       Signalling: connected
+    path option 1, type explicit BYPASS-PATH
+  ...
+  OutLabel : GigabitEthernet0/1, 22
+```
+
+> Résultats attendus :
+> - `Oper: up` pour les deux tunnels
+> - `Path: valid` — chemin RSVP établi
+> - `Explicit Route` correspond au chemin configuré
+> - `OutLabel` montre l'étiquette MPLS attribuée par RSVP
+
+### `show mpls traffic-eng tunnels brief`
+
+```
+PE1# show mpls traffic-eng tunnels brief
+
+                          Tunnel   Destination   Admin  Oper   Path   BW(Kbps)
+Name               Intf   State    Address       State  State  Type   Allocated
+-----------------------------------------------------------------------------------
+PE1_t0             Tu0    up       3.3.3.3       up     up     Exp    100000
+PE1_t1             Tu1    up       3.3.3.3       up     up     Exp    50000
+```
+
+---
+
+## 3. Vérification RSVP / RSVP Verification
+
+### `show ip rsvp neighbors`
+
+```
+PE1# show ip rsvp neighbors
+
+Address          Interface        Messages  Refresh  Timeouts  HelloInt  HelloMisses  HelloState
+10.0.12.2        Gi0/0            47        45       0         10000     4            UP
+10.0.13.2        Gi0/1            23        21       0         10000     4            UP
+```
+
+> `HelloState: UP` pour chaque voisin RSVP — les hellos fonctionnent (requis pour FRR).
+
+### `show ip rsvp installed`
+
+```
+PE1# show ip rsvp installed
+
+RSVP: Gi0/0 has the following installed reservations
+RSVP Reservation. Destination is 3.3.3.3. Source is 1.1.1.1,
+  Protocol is IP, Destination port is 0, Source port is 0
+  Reserved bandwidth: 100K bits/sec, Maximum burst: 1000 bytes, Peak rate: 100K
+  Min Policed Unit: 0 bytes, Max Pkt Size: 1500 bytes
+
+RSVP: Gi0/1 has the following installed reservations
+RSVP Reservation. Destination is 3.3.3.3. Source is 1.1.1.1,
+  Protocol is IP, Destination port is 0, Source port is 0
+  Reserved bandwidth: 50K bits/sec, Maximum burst: 1000 bytes, Peak rate: 50K
+```
+
+### `show mpls traffic-eng link-management bandwidth-allocation`
+
+```
+PE1# show mpls traffic-eng link-management bandwidth-allocation
+
+  System Information::
+    Links (with RSVP): 2
+    Maximum Tunnels: 5
+
+  Link ID:: Gi0/0 (10.0.12.1)
+    Physical Bandwidth    : 1000000 kbits/sec
+    Maximum Reservable BW : 750000  kbits/sec
+    Soft Preempted BW     : 0       kbits/sec
+    Global Pool           :
+      BW Allocated : 100000 kbits/sec   (13% of reservable)
+      BW Soft Preempted : 0 kbits/sec
+      Priority Allocations (kbits/sec):
+        [0]:100000 [1]:0 [2]:0 [3]:0 [4]:0 [5]:0 [6]:0 [7]:0
+
+  Link ID:: Gi0/1 (10.0.13.1)
+    Physical Bandwidth    : 1000000 kbits/sec
+    Maximum Reservable BW : 750000  kbits/sec
+    BW Allocated : 50000 kbits/sec    (6% of reservable)
+```
+
+---
+
+## 4. Vérification de la table de routage / Routing Table
+
+### `show ip route 3.3.3.3`
+
+```
+PE1# show ip route 3.3.3.3
+
+Routing entry for 3.3.3.3/32
+  Known via "ospf 1", distance 110, metric 2, type intra area
+  Routing Descriptor Blocks:
+  * 10.0.12.2, from 3.3.3.3, via GigabitEthernet0/0
+      Route metric is 2, traffic share count is 1
+  via Tunnel0, from 3.3.3.3
+      Route metric is 10, traffic share count is 1
+
+```
+
+> `via Tunnel0` confirme que `autoroute announce` a injecté le tunnel dans la table de routage.
+> Le trafic vers PE2 (3.3.3.3) utilisera le tunnel TE (Tunnel0) et non le chemin IGP direct.
+
+### `show mpls forwarding-table`
+
+```
+PE1# show mpls forwarding-table
+
+Local  Outgoing    Prefix            Bytes Label  Outgoing   Next Hop
+Label  Label       or Tunnel Id      Switched      interface
+16     Pop Label   10.0.12.0/30      0             Gi0/0      10.0.12.2
+17     Pop Label   10.0.13.0/30      0             Gi0/1      10.0.13.2
+18     18          3.3.3.3/32 [T]    2847360       Gi0/0      10.0.12.2
+22     22          3.3.3.3/32 [T]    0             Gi0/1      10.0.13.2
+```
+
+> `[T]` = entrée TE tunnel. Label 18 sur Gi0/0 = tunnel Tunnel0 (primary). Label 22 sur Gi0/1 = Tunnel1 (bypass).
+
+---
+
+## 5. Test du Fast Reroute / FRR Test
+
+### Simuler une panne / Simulate failure
+
+```
+P(config)# interface GigabitEthernet0/0
+P(config-if)# shutdown
+```
+
+### Observer le basculement sur PE1
+
+```
+PE1# show mpls traffic-eng tunnels
+
+Name:PE1_t0                          (Tunnel0) Destination: 3.3.3.3
+  Status:
+    Admin: up         Oper: up     Path: valid       Signalling: connected
+    path option 2, type dynamic (Basis for Setup, path weight 2)  ← BACKUP PATH NOW ACTIVE
+```
+
+> `path option 2, type dynamic` indique que le tunnel a basculé sur l'option de chemin dynamique (via BYPASS).
+> En FRR réel, le basculement se fait en < 50 ms avant même la reconvergence OSPF.
+
+### Vérifier les logs de basculement
+
+```
+PE1# show logging | include Tunnel0|RSVP|FRR
+*Apr 15 10:35:22.443: %MPLS_TE-5-TUNNEL_REROUTED: Tunnel0: Fast Rerouted
+*Apr 15 10:35:22.451: %MPLS_TE-5-TUNNEL_REROUTED: Tunnel0 rerouted to bypass Tunnel1
+```
+
+---
+
+## 6. Récapitulatif de validation / Validation Checklist
+
+| Vérification | Commande | Résultat attendu |
+|--------------|----------|-----------------|
+| OSPF TE topology complète | `show mpls traffic-eng topology` | Tous les liens avec BW visible |
+| Tunnels TE operationnels | `show mpls traffic-eng tunnels brief` | `Oper: up` pour Tunnel0 et Tunnel1 |
+| RSVP voisins up | `show ip rsvp neighbors` | `HelloState: UP` pour P et PE2 |
+| BW réservée correcte | `show mpls traffic-eng link-management bandwidth-allocation` | 100000 kbps sur Gi0/0 |
+| Autoroute injecté | `show ip route 3.3.3.3` | `via Tunnel0` dans la table |
+| LFIB populée | `show mpls forwarding-table` | Entrées `[T]` pour les tunnels |
+| FRR bascule < 50ms | `shutdown` Gi0/0 sur P | `path option 2, dynamic` actif sur PE1 |

--- a/labs/transmission/README.md
+++ b/labs/transmission/README.md
@@ -1,0 +1,50 @@
+# Labs — Transmission (Faisceau Hertzien & Fibre Optique)
+
+## Objectif / Objective
+
+**FR** — Comprendre et maîtriser les technologies de transmission utilisées pour les liaisons inter-sites dans des environnements industriels critiques. Ce lab couvre les deux grands médias de transmission : le **faisceau hertzien (FH)** pour les liaisons point-à-point sans fil, et la **fibre optique** pour les liaisons câblées haute performance. Le contexte principal est celui des **Centres Nucléaires de Production d'Électricité (CNPE) d'EDF**, où la fiabilité et la redondance des liaisons sont critiques.
+
+**EN** — Understand and master the transmission technologies used for inter-site links in critical industrial environments. This lab covers the two main transmission media: **microwave radio (FH — faisceau hertzien)** for wireless point-to-point links, and **fiber optics** for high-performance wired links. The primary context is **EDF Nuclear Power Plants (CNPE)**, where link reliability and redundancy are critical.
+
+---
+
+## Contexte CNPE EDF / CNPE EDF Context
+
+Les CNPE EDF disposent de plusieurs types de liaisons de transmission :
+
+| Type de liaison | Usage typique | Redondance |
+|-----------------|---------------|------------|
+| Fibre optique multi-fibres | Backbone inter-bâtiments | Active/Active, boucle physique |
+| Faisceau hertzien | Liaison de secours ou site isolé | 1+1 (protection de chemin) |
+| Fibre optique longue distance | Liaison CNPE ↔ Dispatching EDF | DWDM, 1+1 |
+| Cuivre / paire torsadée | Réseaux téléphonie / supervision hérités | — |
+
+**Contraintes spécifiques CNPE :**
+- **Disponibilité requise :** 99.999% (5 nines) pour les liaisons critique-sûreté
+- **Environnement électromagnétique :** Interférences possibles depuis les équipements haute tension
+- **Distances :** Quelques centaines de mètres à quelques kilomètres entre bâtiments
+- **Températures :** Câbles et équipements dimensionnés pour -20°C à +70°C
+- **Sécurité physique :** Toute infrastructure passive (chemins de câbles, boîtes d'épissures) en zone contrôlée
+
+---
+
+## Statut / Status
+
+🚧 En cours de construction
+
+---
+
+## Technologies couvertes / Technologies Covered
+
+| Technologie | Document |
+|-------------|----------|
+| Faisceau hertzien (FH) | [faisceau-hertzien.md](faisceau-hertzien.md) |
+| Fibre optique (FO) | [fibre-optique.md](fibre-optique.md) |
+| Procédures de recette | [verification.md](verification.md) |
+
+---
+
+## Liens avec d'autres labs / Related Labs
+
+- [labs/routing/mpls-l3vpn/](../mpls-l3vpn/README.md) — Les liaisons FH/FO portent souvent un backbone MPLS
+- [docs/flux-matrix-IT-OT.md](../../docs/flux-matrix-IT-OT.md) — Les liaisons inter-sites portent les flux IT/OT documentés dans la matrice

--- a/labs/transmission/faisceau-hertzien.md
+++ b/labs/transmission/faisceau-hertzien.md
@@ -1,0 +1,219 @@
+# Faisceau Hertzien (FH) — Principes techniques et bilan de liaison
+# Microwave Radio — Technical Principles and Link Budget
+
+> **Contexte :** Liaisons FH inter-sites pour réseaux industriels critiques (CNPE EDF, sites isolés)
+
+---
+
+## 1. Principes techniques du faisceau hertzien
+
+### 1.1 Définition
+
+Le **faisceau hertzien (FH)** est une liaison radio point-à-point utilisant des fréquences micro-ondes (typiquement 6 à 42 GHz) pour établir une connexion sans fil entre deux sites. Il est utilisé comme alternative ou complément à la fibre optique, notamment pour des sites difficiles d'accès, des traversées de routes ou de voies ferrées, ou comme liaison de secours.
+
+### 1.2 Bandes de fréquences utilisées
+
+| Bande | Fréquence | Distance typique | Débit typique | Conditions atmosphériques |
+|-------|-----------|-----------------|---------------|--------------------------|
+| 7 GHz | 7.1 — 7.9 GHz | 15 — 50 km | 155 Mbps — 1 Gbps | Résistant à la pluie |
+| 13 GHz | 12.75 — 13.25 GHz | 8 — 25 km | 155 Mbps — 1 Gbps | Bon compromis |
+| 18 GHz | 17.7 — 19.7 GHz | 4 — 15 km | 300 Mbps — 1 Gbps | Atténuation pluie modérée |
+| 23 GHz | 21.2 — 23.6 GHz | 2 — 10 km | 300 Mbps — 1 Gbps | Sensible à la pluie |
+| 38 GHz | 37 — 39.5 GHz | 1 — 5 km | 1 Gbps+ | Très sensible à la pluie |
+| E-band | 71 — 86 GHz | 0.5 — 3 km | 10 Gbps+ | Très court, usage urbain |
+
+> **CNPE EDF :** Les bandes **13 GHz et 18 GHz** sont typiquement utilisées pour les liaisons inter-bâtiments. La bande 7 GHz est préférée pour les liaisons longue distance vers le dispatching.
+
+### 1.3 Modulations utilisées
+
+| Modulation | Efficacité spectrale | Sensibilité | Usage |
+|------------|---------------------|-------------|-------|
+| QPSK | Faible | Très bonne | Longues distances, conditions dégradées |
+| 16-QAM | Bonne | Bonne | Compromis distance/débit |
+| 64-QAM | Très bonne | Correcte | Distances moyennes |
+| 128-QAM | Excellente | Correcte | Courtes distances, bon signal |
+| 256-QAM | Maximale | Faible | Très courtes distances, conditions optimales |
+| 1024-QAM | Ultra-haute | Très faible | Usage spécialisé, < 2 km |
+
+> Les équipements modernes utilisent la **modulation adaptative (ACM — Adaptive Coding and Modulation)** : la modulation s'adapte en temps réel aux conditions de propagation. Par temps clair = 1024-QAM, pluie intense = QPSK.
+
+---
+
+## 2. Calcul de bilan de liaison / Link Budget Calculation
+
+Le bilan de liaison détermine si la puissance reçue est suffisante pour maintenir la liaison avec la marge souhaitée.
+
+### 2.1 Formule générale
+
+```
+Received Signal Level (RSL) = EIRP − FSL + Rx Antenna Gain − Rx Cable Losses
+
+Où :
+  EIRP = Tx Power (dBm) + Tx Antenna Gain (dBi) − Tx Cable/Connector Losses (dB)
+  FSL  = Free Space Loss (dB) = 92.4 + 20×log10(f_GHz) + 20×log10(d_km)
+
+Link Margin (FM) = RSL − Rx Threshold (dBm)
+```
+
+### 2.2 Exemple calculé — Liaison 18 GHz, 8 km (typique CNPE)
+
+**Paramètres d'entrée :**
+
+| Paramètre | Valeur |
+|-----------|--------|
+| Fréquence | 18 GHz |
+| Distance | 8 km |
+| Puissance Tx | +15 dBm |
+| Gain antenne Tx | 39 dBi (antenne 0.6m) |
+| Pertes câbles/connecteurs Tx | 1.5 dB |
+| Gain antenne Rx | 39 dBi (antenne 0.6m) |
+| Pertes câbles/connecteurs Rx | 1.5 dB |
+| Seuil Rx (BER 10⁻⁶, 128-QAM) | −82 dBm |
+| Marge minimale requise | 30 dB (cible 99.999% dispo) |
+
+**Calcul pas à pas :**
+
+```
+1. EIRP (Equivalent Isotropically Radiated Power)
+   EIRP = Tx Power + Tx Antenna Gain − Tx Cable Losses
+   EIRP = 15 + 39 − 1.5 = 52.5 dBm
+
+2. Free Space Loss (affaiblissement en espace libre)
+   FSL = 92.4 + 20×log10(18) + 20×log10(8)
+   FSL = 92.4 + 20×1.255 + 20×0.903
+   FSL = 92.4 + 25.1 + 18.1 = 135.6 dB
+
+3. Received Signal Level (RSL)
+   RSL = EIRP − FSL + Rx Antenna Gain − Rx Cable Losses
+   RSL = 52.5 − 135.6 + 39 − 1.5
+   RSL = −45.6 dBm
+
+4. Fade Margin (marge de liaison)
+   FM = RSL − Rx Threshold
+   FM = −45.6 − (−82) = 36.4 dB
+
+5. Conclusion
+   FM = 36.4 dB ≥ 30 dB (requis) → LIAISON VALIDE ✓
+```
+
+**Résumé du bilan :**
+
+| Paramètre | Valeur |
+|-----------|--------|
+| EIRP | +52.5 dBm |
+| Affaiblissement espace libre (FSL) | −135.6 dB |
+| Niveau reçu (RSL) | −45.6 dBm |
+| Seuil Rx (128-QAM) | −82.0 dBm |
+| **Marge de liaison (FM)** | **+36.4 dB** |
+| Marge requise | +30.0 dB |
+| **Statut** | **✅ Liaison valide** |
+
+### 2.3 Atténuation par la pluie (Rain Attenuation)
+
+En bandes > 10 GHz, la pluie introduit une atténuation supplémentaire à prendre en compte pour les liaisons longues.
+
+| Bande | Intensité pluie 20 mm/h | Intensité pluie 50 mm/h | Impact sur 8 km |
+|-------|------------------------|------------------------|-----------------|
+| 13 GHz | ~1 dB/km | ~3 dB/km | 8 — 24 dB |
+| 18 GHz | ~2 dB/km | ~5 dB/km | 16 — 40 dB |
+| 23 GHz | ~3.5 dB/km | ~8 dB/km | 28 — 64 dB |
+
+> Pour 18 GHz sur 8 km avec pluie intense (50 mm/h) : ~40 dB d'atténuation supplémentaire.
+> La marge de 36.4 dB **ne couvre pas** les conditions extrêmes → réduire la distance ou passer en bande 7/13 GHz.
+
+---
+
+## 3. Redondance 1+1
+
+### 3.1 Principe
+
+La redondance **1+1** utilise deux émetteurs/récepteurs sur la même antenne ou sur deux antennes séparées :
+
+| Mode | Description | Commutation |
+|------|-------------|-------------|
+| **Hot Standby** | Les deux radios transmettent, une est active, l'autre en veille chaude | < 50 ms |
+| **Space Diversity** | Deux antennes à hauteurs différentes — réduit les évanouissements par réflexion | Continue / combinaison |
+| **Frequency Diversity** | Deux fréquences légèrement différentes — réduit les évanouissements sélectifs | Continue / sélection |
+
+**Avantage 1+1 :** Si l'équipement actif tombe en panne ou si les conditions se dégradent, la bascule vers le chemin de secours est automatique et quasi-instantanée.
+
+### 3.2 Schéma 1+1
+
+```
+  Site A                              Site B
+┌──────────────┐                   ┌──────────────┐
+│  Antenne     │                   │  Antenne     │
+│  (coupleur)  │                   │  (coupleur)  │
+│  [Radio A1] ─┤─── Faisceau 1 ────┤─ [Radio B1] │  ← Actif
+│  [Radio A2] ─┤─── Faisceau 2 ────┤─ [Radio B2] │  ← Veille (1+1 hot standby)
+│              │                   │              │
+│  [Switch FH] │                   │  [Switch FH] │
+│  (couche 2)  │                   │  (couche 2)  │
+└──────────────┘                   └──────────────┘
+        │                                  │
+  Réseau site A                      Réseau site B
+```
+
+---
+
+## 4. Synchronisation
+
+| Méthode | Description | Précision |
+|---------|-------------|-----------|
+| **IEEE 1588v2 (PTP)** | Protocole de temps précis sur réseau IP — synchronisation fréquence et phase | < 100 ns |
+| **Sync-E (ITU-T G.8262)** | Synchronisation fréquence via couche physique Ethernet | < 1 µs |
+| **GPS intégré** | Récepteur GPS dans l'équipement FH — référence absolue | < 100 ns |
+| **NTP/SNTP** | Synchronisation logicielle via IP — pour les équipements non-critiques | ~1 ms |
+
+> Pour les CNPE EDF : **IEEE 1588v2 + Sync-E** sont typiquement utilisés pour les équipements nécessitant une synchronisation fine (protection différentielle, automatismes).
+
+---
+
+## 5. Intégration dans un réseau MPLS
+
+Le faisceau hertzien transporte les mêmes protocoles que la fibre. En contexte CNPE :
+
+```
+  Site A                    FH (18 GHz)                  Site B
+[PE1 MPLS] ──────────── [Radio A] ─────── [Radio B] ──────────── [PE2 MPLS]
+                         (L2 transparent)
+                         Ethernet GigE
+                         VLAN 802.1Q
+                         ou MPLS directement sur GigE
+```
+
+| Paramètre | Valeur typique |
+|-----------|----------------|
+| Interface côté routeur | GigabitEthernet (1GbE) ou 10GbE |
+| Encapsulation | Ethernet — transparent au MPLS |
+| MTU | 1500 à 9000 octets (jumbo frames si supporté) |
+| QoS | DSCP preservé — le FH peut appliquer QoS sur les priorités Ethernet (CoS 802.1p) |
+| Latence ajoutée | < 1 ms (typiquement 200-500 µs pour 8 km) |
+
+---
+
+## 6. Avantages / Inconvénients vs Fibre optique
+
+| Critère | Faisceau Hertzien (FH) | Fibre Optique |
+|---------|----------------------|---------------|
+| **Déploiement** | ✅ Rapide (quelques jours) | ❌ Long (travaux génie civil) |
+| **Coût initial** | ✅ Faible — pas de tranchées | ❌ Élevé — génie civil, tirage |
+| **Débit** | ❌ Limité (1-10 Gbps max) | ✅ Illimité (100 Gbps+ par fibre) |
+| **Disponibilité** | ⚠️ Dépend conditions météo (pluie, brouillard) | ✅ Très haute — insensible aux intempéries |
+| **Sécurité physique** | ⚠️ Signal interceptable (chiffrement nécessaire) | ✅ Difficile à intercepter sans détection |
+| **Maintenance** | ✅ Pas de câble enterré — alignement antenne | ❌ Risque de coupure physique |
+| **Dégradation** | ⚠️ Évanouissements, pluie, obstacles | ✅ Stable dans le temps |
+| **Sites isolés** | ✅ Idéal (sans infrastructure civile) | ❌ Non applicable sans tranchée |
+| **Longueur typique** | 2 — 50 km (selon bande) | Illimitée (régénérateurs si > 80 km) |
+| **Usage CNPE** | Liaisons de secours, sites isolés | Backbone principal inter-bâtiments |
+
+---
+
+## 7. Normes et réglementation
+
+| Norme / Règlement | Domaine |
+|-------------------|---------|
+| ETSI EN 302 217 | Caractéristiques des systèmes FH en bandes fixes |
+| UIT-R F.382 | Caractéristiques des systèmes fixes par micro-ondes |
+| ARCEP (France) | Attribution des fréquences FH — licence obligatoire par liaison |
+| UIT-R P.530 | Propagation des ondes radio dans les liaisons terrestres |

--- a/labs/transmission/fibre-optique.md
+++ b/labs/transmission/fibre-optique.md
@@ -1,0 +1,237 @@
+# Fibre Optique — Principes, OTDR et mesures
+# Fiber Optics — Principles, OTDR and Measurements
+
+> **Contexte :** Liaisons fibre optique inter-bâtiments en environnement industriel (CNPE EDF)
+
+---
+
+## 1. Types de fibres optiques
+
+### 1.1 Fibre monomode (Single-Mode — SM)
+
+| Norme ITU-T | Nom courant | Diamètre coeur | Usage |
+|-------------|-------------|----------------|-------|
+| **G.652** (A/B/C/D) | SM standard | 9 µm | Liaisons longue distance (LAN, métro, backbone) |
+| **G.657** (A1/A2/B2/B3) | SM bend-insensitive | 9 µm | Installation intérieure, coudes serrés |
+| G.654 | SM ultra-faible atténuation | 9 µm | Sous-marin, très longue distance |
+| G.655 | SM dispersion-shifted (NZDSF) | 9 µm | DWDM longue distance |
+
+> **G.652.D** est la fibre la plus répandue en contexte CNPE et réseau d'entreprise.
+> **G.657.A2** est recommandée pour les passages dans les bâtiments (tolère des rayons de courbure de 7.5 mm).
+
+**Caractéristiques G.652.D :**
+- Atténuation : ≤ 0.35 dB/km à 1310 nm, ≤ 0.20 dB/km à 1550 nm
+- Dispersion chromatique : ≤ 3.5 ps/(nm·km) à 1310 nm
+- Longueurs d'onde de travail : 1310 nm et 1550 nm (CWDM/DWDM jusqu'à 1625 nm)
+
+### 1.2 Fibre multimode (Multi-Mode — MM)
+
+| Norme ISO/IEC 11801 | Diamètre coeur | Bande passante | Distance max (10GbE) |
+|---------------------|----------------|----------------|---------------------|
+| OM1 | 62.5 µm | 200 MHz·km | 33 m |
+| OM2 | 50 µm | 500 MHz·km | 82 m |
+| OM3 | 50 µm | 2000 MHz·km | 300 m |
+| OM4 | 50 µm | 4700 MHz·km | 550 m |
+| OM5 | 50 µm | 28000 MHz·km | 400 m (SWDM4) |
+
+> En contexte CNPE : la fibre **monomode G.652.D** est utilisée pour les liaisons inter-bâtiments. La multimode OM3/OM4 est réservée aux salles serveurs et câblages horizontaux courts.
+
+---
+
+## 2. Connecteurs
+
+| Connecteur | Type | Usage | Ferrule |
+|------------|------|-------|---------|
+| **LC** (Lucent Connector) | Petit form factor | SFP, SFP+, QSFP — équipements actifs | 1.25 mm |
+| **SC** (Subscriber Connector) | Standard | Panneaux de brassage, boîtiers d'épissure | 2.5 mm |
+| **MPO/MTP** | Multi-fibres (8/12/24 fibres) | Backbone haute densité, 40/100GbE | Ribbons |
+| **FC** | Verrouillage vissé | Mesures OTDR, environnements vibratoires | 2.5 mm |
+| **ST** | Baïonnette | Équipements anciens (legacy) | 2.5 mm |
+
+**Polissage des ferrules :**
+
+| Polissage | Réflectance | Usage |
+|-----------|-------------|-------|
+| PC (Physical Contact) | −30 à −40 dB | Multimode, réseaux classiques |
+| UPC (Ultra PC) | −40 à −55 dB | Monomode standard |
+| APC (Angled PC, 8°) | −60 à −70 dB | CATV, WDM, mesures de précision |
+
+> **Règle :** Ne jamais connecter un UPC avec un APC — incompatibilité physique et forte perte d'insertion.
+
+---
+
+## 3. OTDR — Optical Time Domain Reflectometer
+
+### 3.1 Principe de fonctionnement
+
+L'OTDR envoie des impulsions lumineuses dans la fibre et mesure la lumière rétrodiffusée (rétrodiffusion Rayleigh) et réfléchie (réflexions de Fresnel aux connecteurs et épissures). Le temps de retour de l'écho permet de localiser les événements sur la fibre.
+
+```
+Principe de mesure :
+  OTDR ──► impulsion lumineuse ──► Fibre optique ──►
+                                          │
+                  Rétrodiffusion Rayleigh ◄┘ (continue, pente = atténuation)
+                  Réflexion Fresnel ◄─────── (pics aux connecteurs)
+```
+
+### 3.2 Paramètres de réglage OTDR
+
+| Paramètre | Description | Réglage typique |
+|-----------|-------------|-----------------|
+| Longueur d'onde (λ) | 1310 nm (dommage, splice) / 1550 nm (atténuation) | Tester les deux |
+| Largeur d'impulsion | Impulsion courte = résolution, longue = portée | 10-30 ns pour < 5 km |
+| Plage de mesure | Distance maximale affichée | 2× longueur estimée |
+| Index de réfraction (IOR) | Spécifique au type de fibre | G.652: 1.4682 à 1310nm |
+| Moyenne | Nombre de mesures moyennées | 16-64 pour une bonne courbe |
+
+### 3.3 Événements OTDR
+
+| Type d'événement | Représentation | Cause |
+|-----------------|----------------|-------|
+| Épissure (fusion splice) | Petite marche vers le bas | Soudure de deux fibres |
+| Connecteur | Pic de réflexion + perte | Connecteur SC/LC/FC |
+| Courbure excessive | Perte sans réflexion | Rayon de courbure trop serré |
+| Cassure / rupture | Forte perte ou fin abrupte | Fibre cassée |
+| Fin de fibre | Réflexion finale forte | Extrémité clivée ou connecteur |
+
+---
+
+## 4. Exemple de rapport OTDR — Liaison 2 km entre deux bâtiments CNPE
+
+### 4.1 Contexte
+
+```
+Bâtiment A (Salle électrique)  ──── Câble G.652.D 12 FO ────  Bâtiment B (Salle serveurs)
+Boîte d'épissure 1 (BE-01)          ~100 m        ~1000 m       Boîte d'épissure 2 (BE-02)
+     |                                               |
+  Splice 1                                        Splice 2+3
+```
+
+### 4.2 Trace OTDR — Wavelength 1310 nm
+
+```
+Niveau (dB)
+   0 ─┐
+      │ ← Pic de lancement (connecteur départ SC/APC)
+  0.25─┼────────────────────────────────────────────────────
+      │         Pente continue = atténuation fibre G.652.D
+      │         (0.35 dB/km à 1310nm → pente ~0.35 dB/km)
+  0.30─┤ ← Splice 1 à ~95 m (dans BE-01) [perte 0.04 dB]
+      │
+  0.50─┤ ← Splice 2 à ~540 m (jonction câble) [perte 0.07 dB]
+      │
+  0.73─┤ ← Splice 3 à ~1000 m (mid-span) [perte 0.05 dB]
+      │
+  0.95─┤ ← Splice 4 à ~1450 m [perte 0.06 dB]
+      │
+  1.20─┤ ← Splice 5 à ~1900 m (dans BE-02) [perte 0.03 dB]
+      │
+  1.49─┼── Connecteur d'arrivée SC/APC à 2000 m [perte 0.28 dB]
+      │                                          [réflexion -35 dB]
+  1.55─┘ END OF FIBER
+       0       0.5      1.0      1.5      2.0 km
+```
+
+### 4.3 Tableau des événements / Events Table (1310 nm)
+
+| # | Distance (km) | Type d'événement | Perte insertion (dB) | Réflexion (dB) | Acceptable ? |
+|---|---------------|-----------------|---------------------|---------------|-------------|
+| 1 | 0.000 | Connecteur départ (SC/APC) | 0.25 | −35.0 | ✅ < 0.5 dB |
+| 2 | 0.095 | Épissure fusion (BE-01) | 0.04 | — | ✅ < 0.1 dB |
+| 3 | 0.543 | Épissure fusion (jonction câble) | 0.07 | — | ✅ < 0.1 dB |
+| 4 | 0.998 | Épissure fusion (mi-parcours) | 0.05 | — | ✅ < 0.1 dB |
+| 5 | 1.445 | Épissure fusion (jonction câble) | 0.06 | — | ✅ < 0.1 dB |
+| 6 | 1.902 | Épissure fusion (BE-02) | 0.03 | — | ✅ < 0.1 dB |
+| 7 | 2.000 | Connecteur arrivée (SC/APC) | 0.28 | −34.8 | ✅ < 0.5 dB |
+| — | 2.000 | FIN DE FIBRE | — | — | — |
+
+### 4.4 Bilan optique / Optical Budget Summary
+
+| Composante | Calcul | Valeur |
+|------------|--------|--------|
+| Atténuation fibre (G.652.D, 1310 nm) | 2.0 km × 0.35 dB/km | 0.70 dB |
+| Pertes épissures (5 × moy. 0.05 dB) | 5 × 0.05 | 0.25 dB |
+| Perte connecteur départ | — | 0.25 dB |
+| Perte connecteur arrivée | — | 0.28 dB |
+| **Atténuation totale mesurée** | | **1.49 dB** |
+| **Budget optique disponible** | (SFP 1310nm: −3 à −8 dBm Tx, −14 dBm Rx min) | ~11 dB |
+| **Marge optique** | 11 − 1.49 | **9.5 dB** ✅ |
+
+### 4.5 Mesures à 1550 nm (comparaison)
+
+| Composante | Calcul | Valeur |
+|------------|--------|--------|
+| Atténuation fibre (G.652.D, 1550 nm) | 2.0 km × 0.20 dB/km | 0.40 dB |
+| Pertes épissures | 5 × 0.04 | 0.20 dB |
+| Perte connecteurs | 0.25 + 0.28 | 0.53 dB |
+| **Total 1550 nm** | | **1.13 dB** |
+
+---
+
+## 5. Seuils d'acceptabilité / Acceptance Thresholds
+
+### 5.1 Pertes d'insertion (IL — Insertion Loss)
+
+| Élément | Seuil acceptable | Seuil alarme |
+|---------|-----------------|--------------|
+| Épissure fusion (fusion splice) | ≤ 0.10 dB | > 0.10 dB |
+| Épissure mécanique | ≤ 0.30 dB | > 0.30 dB |
+| Connecteur SC/LC UPC | ≤ 0.50 dB | > 0.50 dB |
+| Connecteur SC/LC APC | ≤ 0.30 dB | > 0.30 dB |
+| Connecteur MPO | ≤ 0.60 dB (12 fibres) | > 0.60 dB |
+| Atténuation fibre G.652.D 1310nm | ≤ 0.40 dB/km | > 0.40 dB/km |
+| Atténuation fibre G.652.D 1550nm | ≤ 0.25 dB/km | > 0.25 dB/km |
+
+### 5.2 Pertes de retour (RL — Return Loss / Reflectance)
+
+| Élément | Seuil acceptable |
+|---------|-----------------|
+| Connecteur UPC | ≥ 40 dB (réflectance ≤ −40 dB) |
+| Connecteur APC | ≥ 60 dB (réflectance ≤ −60 dB) |
+| Épissure fusion | Non réflective (< −55 dB) |
+
+---
+
+## 6. Splice vs Connecteur
+
+| Critère | Épissure fusion (Fusion Splice) | Connecteur (Mechanical) |
+|---------|--------------------------------|------------------------|
+| **Perte typique** | 0.02 — 0.10 dB | 0.15 — 0.50 dB |
+| **Réflexion** | Quasi-nulle (< −60 dB) | Modérée (−30 à −55 dB) |
+| **Durabilité** | Permanente (> 30 ans) | Usure des ferrules (nettoyage régulier) |
+| **Démontable** | ❌ Non — soudure permanente | ✅ Oui — brassage flexible |
+| **Usage** | Infrastructures permanentes (backbone) | Panneaux de brassage, équipements actifs |
+| **Outillage** | Soudeuse arc (5 000 — 30 000 €) | Outil de polissage ou connecteurs préfabriqués |
+| **CNPE** | Câbles enterrés, boîtes d'épissures | Baies de brassage, salles techniques |
+
+---
+
+## 7. Budget optique / Optical Power Budget
+
+```
+Budget optique = Puissance Tx (dBm) − Sensibilité Rx (dBm) − Marge système (dB)
+
+Exemple : SFP 1000BASE-LX (1310 nm, 10 km)
+  Puissance Tx min : −3 dBm
+  Sensibilité Rx   : −19 dBm
+  Budget brut      : 16 dB
+  Marge système    : 3 dB (vieillissement, température)
+  Budget utilisable: 13 dB
+
+  Budget consommé par le lien 2 km : 1.49 dB
+  Marge restante : 13 − 1.49 = 11.5 dB ✅ (très confortable)
+```
+
+---
+
+## 8. Normes de câblage / Cabling Standards
+
+| Norme | Domaine |
+|-------|---------|
+| **TIA-568.3-D** | Câblage fibre optique — Amérique du Nord |
+| **EN 50173-1** | Infrastructure de câblage générique — Europe |
+| **IEC 14763-3** | Installation et tests des câblages fibre optique |
+| **IEC 61300-3-35** | Tests de propreté des connecteurs optiques |
+| **IEC 61754** | Normes des connecteurs optiques (SC, LC, MPO...) |
+| **ITU-T G.652** | Caractéristiques des fibres monomode G.652 |
+| **ITU-T G.657** | Fibres résistantes aux courbures |

--- a/labs/transmission/verification.md
+++ b/labs/transmission/verification.md
@@ -1,0 +1,262 @@
+# Verification — Procédures de recette Fibre Optique & Faisceau Hertzien
+# Acceptance Test Procedures — Fiber Optics & Microwave Radio
+
+> **Usage :** Procédures à suivre lors des recettes de liaisons neuves ou rénovées.
+> Ces procédures permettent de constituer les documents remis au client ou au maître d'oeuvre.
+
+---
+
+## 1. Recette fibre optique / Fiber Optic Acceptance
+
+### 1.1 Prérequis
+
+| Prérequis | Vérification |
+|-----------|-------------|
+| Câble tiré et épissures terminées | Visual inspection — boîtes d'épissures fermées |
+| Connecteurs posés et nettoyés | Inspection avec microscope + Alcool isopropylique 99% |
+| Plan de câblage disponible | Numérotation des fibres, longueurs estimées |
+| Appareils calibrés | OTDR avec certificat de calibration < 1 an |
+| Fiche de recette vierge | Document à compléter pendant les mesures |
+
+### 1.2 Matériel nécessaire
+
+| Outil | Modèle type | Usage |
+|-------|-------------|-------|
+| OTDR | Viavi MTS-2000 / EXFO FTB-1-Pro | Mesure des événements et atténuation |
+| Source optique | EXFO FLS-300 | Mesure de perte d'insertion bidirectionnelle |
+| Puissance-mètre | EXFO FPM-302 | Mesure en liaison avec la source |
+| Microscope de connecteur | EXFO FIP-425B | Inspection de la propreté des ferrules |
+| Kit de nettoyage | Opticspro FCC | Nettoyage des connecteurs avant mesure |
+| Cordons de référence | Certifiés < 0.2 dB chacun | Cordons de lancement/réception OTDR |
+
+### 1.3 Procédure OTDR
+
+**Étape 1 — Préparation**
+
+1. Nettoyer tous les connecteurs du lien à mesurer (embout + ferrule)
+2. Inspecter avec le microscope : aucune égratignure sur la zone de contact, aucune poussière
+3. Connecter les cordons de lancement (launch cable, ~50-100 m) pour masquer la zone morte OTDR
+4. Régler l'OTDR :
+   - λ = 1310 nm (mesure 1) puis 1550 nm (mesure 2)
+   - Plage = 2× longueur estimée (ex: 5 km pour lien de 2 km)
+   - Impulsion = 10-30 ns pour liens < 5 km
+   - IOR = 1.4682 (G.652.D à 1310 nm) / 1.4676 (à 1550 nm)
+   - Moyenne = 64 passes minimum
+
+**Étape 2 — Mesure OTDR bidirectionnelle**
+
+> La mesure doit être effectuée dans les **deux sens** (A→B puis B→A). La perte d'une épissure est la moyenne des deux mesures directionnelles.
+
+```
+Mesure A→B :
+  OTDR connecté en A → mesure vers B
+  Enregistrer la trace, identifier tous les événements
+
+Mesure B→A :
+  OTDR connecté en B → mesure vers A
+  Enregistrer la trace, identifier tous les événements
+```
+
+**Étape 3 — Mesure de perte d'insertion (Source/Puissance-mètre)**
+
+```
+Source optique (A) ──── Lien complet ──── Puissance-mètre (B)
+
+1. Mesurer la puissance de référence (cordon direct source → puissance-mètre) → P_ref
+2. Insérer le lien à mesurer → P_lien
+3. Perte d'insertion = P_ref - P_lien (en dB)
+4. Répéter dans l'autre sens (B→A)
+5. Résultat final = moyenne des deux mesures bidirectionnelles
+```
+
+### 1.4 Seuils de recette fibre optique
+
+| Mesure | Critère de réception | Action si hors seuil |
+|--------|---------------------|---------------------|
+| Atténuation totale du lien | ≤ Budget calculé − 3 dB de marge | Identifier et reprendre l'élément défaillant |
+| Perte insertion par épissure | ≤ 0.10 dB (fusion) | Refaire l'épissure |
+| Perte insertion connecteur | ≤ 0.50 dB (UPC) / ≤ 0.30 dB (APC) | Nettoyer ou remplacer le connecteur |
+| Atténuation /km à 1310nm | ≤ 0.40 dB/km | Vérifier le type de fibre installé |
+| Atténuation /km à 1550nm | ≤ 0.25 dB/km | Vérifier la fibre + courbures excessives |
+| Longueur mesurée vs plan | ≤ 5% d'écart | Vérifier le plan et l'IOR |
+
+### 1.5 Tableau de recette OTDR — Modèle / Acceptance Record Template
+
+```
+PROCÈS-VERBAL DE RECETTE FIBRE OPTIQUE
+═══════════════════════════════════════════════════════════
+Projet      : ___________________________
+Site A      : ___________________________
+Site B      : ___________________________
+Date        : ___________________________
+Technicien  : ___________________________
+OTDR        : Marque ____________ S/N ____________
+Calibration : Valide jusqu'au _______________
+
+CÂBLE
+Type        : G.652.D  /  G.657.A2  /  OM3  /  OM4  (entourer)
+Référence   : ___________________________
+Longueur déclarée : _______ m
+Longueur OTDR     : _______ m  (écart : _____ %)
+
+MESURES PAR FIBRE (tableau à répéter par fibre)
+─────────────────────────────────────────────────────────────
+Fibre N° : _____   Couleur : _______
+
+  Sens A→B (1310 nm)
+  Atténuation totale  : _____ dB   Limite : _____ dB  [ ]OK [ ]NOK
+  Nb événements       : _____
+  Perte max épissure  : _____ dB   Limite : 0.10 dB   [ ]OK [ ]NOK
+  Perte connecteurs   : _____ dB   Limite : 0.50 dB   [ ]OK [ ]NOK
+
+  Sens B→A (1310 nm)
+  Atténuation totale  : _____ dB   Limite : _____ dB  [ ]OK [ ]NOK
+  Perte max épissure  : _____ dB   Limite : 0.10 dB   [ ]OK [ ]NOK
+
+  Sens A→B (1550 nm)
+  Atténuation totale  : _____ dB   Limite : _____ dB  [ ]OK [ ]NOK
+  Perte /km           : _____ dB   Limite : 0.25 dB   [ ]OK [ ]NOK
+
+  Résultat final      : [ ]CONFORME  [ ]NON CONFORME
+─────────────────────────────────────────────────────────────
+
+CONCLUSION
+[ ] Toutes les fibres conformes — LIEN ACCEPTÉ
+[ ] Non-conformités relevées — ACTIONS CORRECTIVES REQUISES
+
+Signature technicien : ___________________  Date : _________
+Signature client/MOE : ___________________  Date : _________
+═══════════════════════════════════════════════════════════
+```
+
+---
+
+## 2. Recette faisceau hertzien / Microwave Radio Acceptance
+
+### 2.1 Prérequis
+
+| Prérequis | Vérification |
+|-----------|-------------|
+| Pylônes / mâts installés et certifiés | PV de levage et certificat structural |
+| Autorisation ARCEP obtenue | Numéro de licence et fréquences autorisées |
+| Alignement visuel antennes | Visible à l'oeil nu / binoculaires |
+| Dégagement de Fresnel > 60% | Calcul de profil avec logiciel (Pathloss, EDX) |
+| Câble coaxial ou fibre interne | Installation conforme, protection UV |
+| Équipements alimentés | Alimentation et mise à la terre conformes |
+
+### 2.2 Procédure d'alignement d'antennes
+
+```
+Étape 1 — Alignement grossier
+  - Utiliser une boussole et un inclinomètre pour pointer grossièrement
+  - Azimut calculé (ex: 245°) — marge ±5°
+  - Tilt vertical calculé selon hauteur et distance
+
+Étape 2 — Alignement fin avec signal
+  - Connecter l'RSSI (Received Signal Strength Indicator) sur l'équipement
+  - Depuis le site B : monitorer le RSL en continu
+  - Depuis le site A : ajuster l'azimut par pas de 0.1°, puis l'élévation
+  - Chercher le RSL maximum — noter la valeur pic
+  - Serrer les vis de maintien des 2 antennes
+  - Vérifier que le RSL ne chute pas après serrage
+
+Étape 3 — Vérification de la polarisation
+  - H/V (Horizontal/Vertical) — configurer les deux antennes identiquement
+  - Ou XPIC (Cross-Polarization Interference Cancellation) pour doublement de capacité
+```
+
+### 2.3 Mesures à effectuer
+
+| Mesure | Méthode | Seuil acceptable |
+|--------|---------|-----------------|
+| RSL (Received Signal Level) | Lecture sur interface de gestion | > RSL_calculé − 3 dB |
+| Marge de liaison (Fade Margin) | RSL − Seuil Rx | ≥ 30 dB (disponibilité 99.999%) |
+| BER (Bit Error Rate) | Interface de gestion | ≤ 10⁻⁶ en conditions normales |
+| Débit mesuré | Test iPerf ou équipement dédié | ≥ 95% du débit nominal |
+| XPD (Cross-Polar Discrimination) | Si XPIC activé | ≥ 40 dB |
+| Latence aller-retour | Ping avec timestamp | ≤ 2 ms pour 10 km |
+| Disponibilité sur 24h | Monitoring continu | Aucune coupure > 10 s |
+
+### 2.4 Tableau de recette FH — Modèle / FH Acceptance Record Template
+
+```
+FICHE DE RECETTE FAISCEAU HERTZIEN
+═══════════════════════════════════════════════════════════
+Projet         : ___________________________
+Liaison        : Site A : _______  ←──→  Site B : _______
+Distance       : _______ km
+Fréquence Tx/Rx: _______/_______  GHz
+Polarisation   : H / V / XPIC (entourer)
+Modulation     : _______________  (ex: 128-QAM)
+Débit nominal  : _______ Mbps
+Date recette   : ___________________________
+Techniciens    : ___________________________ (Site A)
+                 ___________________________ (Site B)
+
+BILAN DE LIAISON CALCULÉ
+EIRP              : _______ dBm
+FSL               : _______ dB
+RSL calculé       : _______ dBm
+Seuil Rx          : _______ dBm
+Marge calculée    : _______ dB   [ ]≥30 dB ✅  [ ]<30 dB ❌
+
+MESURES TERRAIN (Site A ←──→ Site B)
+─────────────────────────────────────────────────────────
+  RSL mesuré (Site A→B)  : _______ dBm   [ ]OK [ ]NOK
+  RSL mesuré (Site B→A)  : _______ dBm   [ ]OK [ ]NOK
+  Marge réelle           : _______ dB    [ ]≥30 dB [ ]<30 dB
+  BER en conditions normales: ________   [ ]≤10⁻⁶ [ ]>10⁻⁶
+  Débit mesuré (iPerf)   : _______ Mbps  [ ]≥95% du nominal
+
+TEST DE REDONDANCE 1+1
+  Bascule Radio A → Radio B  : [ ]OK < 50ms  [ ]NOK
+  Bascule Radio B → Radio A  : [ ]OK < 50ms  [ ]NOK
+  RSL après bascule          : _______ dBm   [ ]Stable
+
+SYNCHRONISATION
+  Mode synchronisation       : IEEE 1588 / Sync-E / GPS (entourer)
+  Alarme sync               : [ ]Aucune  [ ]En cours
+  MTIE mesuré (si applicable): _______ ns   [ ]≤100 ns ✅
+
+TEST DE DISPONIBILITÉ (24h monitoring)
+  Durée de test              : 24h — de _______ à _______
+  Coupures > 1s             : _______ (seuil : 0 pour 99.999%)
+  Disponibilité calculée     : _______ %   [ ]≥99.999% ✅
+
+DOCUMENTS REMIS
+  [ ] Traces OTDR (si liaison mixte FH + FO)
+  [ ] Rapport de bilan de liaison calculé
+  [ ] Certificat d'alignement des antennes (angles azimut/tilt)
+  [ ] Licence ARCEP
+  [ ] Plan de configuration équipements (fréquences, modulation, codes)
+  [ ] Rapport de monitoring 24h
+
+CONCLUSION
+[ ] Liaison conforme — FH ACCEPTÉ
+[ ] Non-conformités relevées — ACTIONS CORRECTIVES REQUISES
+
+Observations : ________________________________________________
+_______________________________________________________________
+
+Signature technicien A : _________________  Date : ___________
+Signature technicien B : _________________  Date : ___________
+Signature client/MOE   : _________________  Date : ___________
+═══════════════════════════════════════════════════════════
+```
+
+---
+
+## 3. Récapitulatif des documents à produire / Deliverables Summary
+
+| Document | Fibre optique | Faisceau hertzien |
+|----------|:-------------:|:-----------------:|
+| PV de recette OTDR | ✅ Obligatoire | — |
+| Traces OTDR exportées (.sor) | ✅ Obligatoire | — |
+| Rapport de pertes d'insertion | ✅ Obligatoire | — |
+| Fiche de recette FH | — | ✅ Obligatoire |
+| Bilan de liaison calculé | — | ✅ Obligatoire |
+| Rapport de monitoring 24h | — | ✅ Obligatoire |
+| Licence ARCEP | — | ✅ Obligatoire |
+| Plan de câblage / schéma | ✅ Recommandé | ✅ Recommandé |
+| Photos de l'installation | ✅ Recommandé | ✅ Obligatoire (antennes) |
+| Rapport de nettoyage connecteurs | ✅ Recommandé | — |


### PR DESCRIPTION
## Summary

- **`labs/routing/juniper-junos-basics/`** — Lab complet JunOS : configs SRX, cheatsheet IOS↔JunOS, vérification
- **`labs/transmission/`** — Lab transmission : FH (bilan de liaison) + fibre optique (OTDR 2km CNPE) + recettes
- **`labs/routing/mpls-traffic-engineering/`** — Lab MPLS-TE : RSVP-TE, tunnels explicites, FRR < 50ms

---

## Détail — labs/routing/juniper-junos-basics/ (7 fichiers)

| Fichier | Contenu |
|---------|---------|
| `README.md` | Objectifs, comparaison IOS/JunOS, tableau technologies |
| `topology.md` | Topologie triangle eBGP — SRX1 (65001), SRX2 (65002), R1 Cisco (65003) — plans /30 et /32 |
| `configs/SRX1.junos` | Config complète hiérarchique JunOS : interfaces, firewall filter PROTECT-RE, routing-options, BGP 2 groupes eBGP, policy-options (export/import), security zones/policies/IDS |
| `configs/SRX2.junos` | Config miroir AS 65002 |
| `configs/R1-cisco.ios` | Config Cisco IOS-XE : BGP eBGP, prefix-list, route-map, ACL PROTECT-RE, SSH v2 hardening |
| `junos-vs-ios-cheatsheet.md` | 8 sections : modes CLI, commit/rollback, interfaces, table de routage, BGP, filtrage/policy, firewall filters, diagnostics |
| `verification.md` | Commandes `show` JunOS avec output attendu : `show interfaces terse`, `show bgp summary`, `show route protocol bgp`, `show firewall filter`, `show system commit` |

Placeholders : `<BGP-PASSWORD-HERE>`, `<ADMIN-PASSWORD-HERE>` — aucun secret réel committé.

---

## Détail — labs/transmission/ (4 fichiers)

| Fichier | Contenu |
|---------|---------|
| `README.md` | Contexte CNPE EDF, types de liaisons (FH/FO/DWDM), contraintes industrielles |
| `faisceau-hertzien.md` | Bandes 7/13/18/23 GHz, modulations (QPSK→1024QAM, ACM), **calcul complet bilan de liaison 18 GHz 8 km** (EIRP=52.5 dBm, FSL=135.6 dB, RSL=−45.6 dBm, FM=36.4 dB ✅), atténuation pluie, redondance 1+1 (hot standby/space/freq diversity), synchronisation PTP/Sync-E, intégration MPLS, tableau FH vs fibre |
| `fibre-optique.md` | Fibres G.652.D/G.657/OM3-4, connecteurs LC/SC/MPO/APC/UPC, principes OTDR, **exemple complet liaison 2km CNPE** (7 événements, tableau IL/RL, bilan optique 1.49 dB), seuils IL/RL, splice vs connecteur, normes TIA-568/EN-50173 |
| `verification.md` | Procédure OTDR bidirectionnelle + template PV de recette fibre, procédure alignement antennes FH + fiche de recette FH (RSL, BER, 24h monitoring, 1+1 test), tableau des livrables à produire |

---

## Détail — labs/routing/mpls-traffic-engineering/ (6 fichiers)

| Fichier | Contenu |
|---------|---------|
| `README.md` | LDP vs RSVP-TE (tableau comparatif), cas d'usage QoS/redondance/load-balancing |
| `topology.md` | PE1(1.1.1.1) — P(2.2.2.2) — PE2(3.3.3.3) + lien direct bypass, tunnels TE détaillés (BW, path options, FRR), table d'allocation BW par lien |
| `configs/PE1-TE.ios` | Ingress PE : OSPF-TE (`mpls traffic-eng area 0`), RSVP (`ip rsvp bandwidth`), Tunnel0 (100 Mbps, explicit PRIMARY-PATH, autoroute, FRR), Tunnel1 (50 Mbps, bypass FRR, `protect-from`), chemins explicites stricts |
| `configs/P-TE.ios` | Transit P : OSPF-TE extensions, RSVP hellos, commentaire bypass optionnel |
| `configs/PE2-TE.ios` | Egress PE : OSPF-TE, RSVP, notes config bidirectionnelle |
| `verification.md` | `show mpls traffic-eng topology`, `show mpls traffic-eng tunnels [brief]`, `show ip rsvp neighbors`, `show mpls traffic-eng link-management bandwidth-allocation`, `show mpls forwarding-table`, test FRR avec `shutdown` + logs de basculement |

## Test plan

- [ ] Vérifier que les configs `.junos` s'affichent correctement (syntaxe hiérarchique)
- [ ] Vérifier que les configs `.ios` s'affichent correctement (syntaxe IOS)
- [ ] Vérifier les placeholders : aucun mot de passe réel — uniquement `<BGP-PASSWORD-HERE>`, `<ADMIN-PASSWORD-HERE>`
- [ ] Vérifier les diagrammes ASCII dans topology.md et verification.md
- [ ] Vérifier les liens croisés entre labs (mpls-te → mpls-l3vpn, transmission → docs/)

https://claude.ai/code/session_0157qF7nnEbjy2XTKVPMXQGh