### PR TITLE
Add DevNet OSPF lab documentation and configuration

### DIFF
--- a/labs/devnet-ospf/README.md
+++ b/labs/devnet-ospf/README.md
@@ -1,0 +1,100 @@
+# Lab — DevNet OSPF (Always-On Sandbox)
+
+## Objectif / Objective
+
+**FR** — Configurer OSPF Area 0 sur les interfaces loopback d'un routeur Cisco C8000V via le sandbox DevNet Always-On. Le lab démontre la mise en place d'un OSPF PID 1 avec deux loopbacks (Lo0 et Lo100) redistribuées dans l'area backbone.
+
+**EN** — Configure OSPF Area 0 on loopback interfaces of a Cisco C8000V router using the DevNet Always-On Sandbox. The lab demonstrates setting up OSPF PID 1 with two loopbacks (Lo0 and Lo100) advertised into the backbone area.
+
+---
+
+## Plateforme / Platform
+
+| Paramètre | Valeur |
+|-----------|--------|
+| Équipement | Cisco C8000V |
+| Version IOS XE | 17.15.04c |
+| Environnement | DevNet Always-On Sandbox |
+| Accès | SSH / RESTCONF |
+
+---
+
+## Topologie / Topology
+
+```
++---------------------------+
+|   Cisco C8000V (C8KV)     |
+|                           |
+|  Loopback0  1.1.1.1/32    |  ─── OSPF Area 0 (PID 1)
+|  Loopback100 10.100.100.1/32 |     router-id 1.1.1.1
+|                           |
++---------------------------+
+```
+
+---
+
+## Interfaces configurées / Configured Interfaces
+
+| Interface | Adresse IP | Masque | OSPF Area |
+|-----------|-----------|--------|-----------|
+| Loopback0 | 1.1.1.1 | /32 (255.255.255.255) | Area 0 |
+| Loopback100 | 10.100.100.1 | /32 (255.255.255.255) | Area 0 |
+
+---
+
+## Configuration appliquée / Applied Configuration
+
+Voir / See: [`ospf_config.txt`](ospf_config.txt)
+
+```
+interface Loopback0
+ ip address 1.1.1.1 255.255.255.255
+!
+interface Loopback100
+ ip address 10.100.100.1 255.255.255.255
+!
+router ospf 1
+ router-id 1.1.1.1
+ network 1.1.1.1 0.0.0.0 area 0
+ network 10.100.100.1 0.0.0.0 area 0
+```
+
+---
+
+## Commandes de vérification / Verification Commands
+
+```
+show ip ospf
+show ip ospf interface brief
+show ip ospf neighbor
+show ip route ospf
+```
+
+### Résultat attendu / Expected Output
+
+`show ip ospf` doit afficher / should show:
+- Process ID: 1
+- Router ID: 1.1.1.1
+- Area 0 active
+
+`show ip ospf interface brief` doit afficher / should show:
+- Loopback0 dans Area 0
+- Loopback100 dans Area 0
+
+---
+
+## Statut / Status
+
+Complété — configuration validée sur DevNet Always-On Sandbox.
+
+---
+
+## Technologies utilisées / Technologies Used
+
+| Technologie | Rôle |
+|-------------|------|
+| Cisco C8000V | Plateforme de routage cloud-native |
+| IOS XE 17.15.04c | Système d'exploitation |
+| OSPFv2 | Protocole IGP link-state (Area 0) |
+| DevNet Always-On | Sandbox de test Cisco en ligne |
+| SSH / RESTCONF | Accès et automatisation |

--- a/labs/devnet-ospf/ospf_config.txt
+++ b/labs/devnet-ospf/ospf_config.txt
@@ -1,0 +1,25 @@
+! ============================================================
+! Lab : DevNet OSPF — Cisco C8000V, IOS XE 17.15.04c
+! Platform : DevNet Always-On Sandbox
+! Objective : OSPF Area 0 on loopback interfaces
+! ============================================================
+
+interface Loopback0
+ ip address 1.1.1.1 255.255.255.255
+!
+interface Loopback100
+ ip address 10.100.100.1 255.255.255.255
+!
+router ospf 1
+ router-id 1.1.1.1
+ network 1.1.1.1 0.0.0.0 area 0
+ network 10.100.100.1 0.0.0.0 area 0
+!
+
+! ============================================================
+! Verification commands:
+!   show ip ospf
+!   show ip ospf interface brief
+!   show ip ospf neighbor
+!   show ip route ospf
+! ============================================================


### PR DESCRIPTION
## Summary
This PR adds a new lab guide for configuring OSPF Area 0 on a Cisco C8000V router using the DevNet Always-On Sandbox. The lab includes comprehensive documentation and the complete configuration needed to set up OSPF with loopback interfaces.

## Changes
- **README.md**: Added bilingual (French/English) lab documentation including:
  - Lab objectives and platform specifications
  - Network topology diagram
  - Configured interfaces table (Loopback0 and Loopback100)
  - Applied OSPF configuration with router-id and area assignments
  - Verification commands and expected outputs
  - Technologies used and completion status

- **ospf_config.txt**: Added the complete CLI configuration file containing:
  - Loopback0 interface configuration (1.1.1.1/32)
  - Loopback100 interface configuration (10.100.100.1/32)
  - OSPF process 1 setup with router-id 1.1.1.1
  - Network statements for both loopbacks in Area 0
  - Verification command reference

## Implementation Details
- Configuration uses OSPF Process ID 1 with router-id 1.1.1.1
- Both loopback interfaces are advertised into the backbone area (Area 0) using /32 host routes
- Lab is validated and tested on DevNet Always-On Sandbox with IOS XE 17.15.04c
- Documentation provides both SSH and RESTCONF access methods for automation

https://claude.ai/code/session_01XgBVcPxpXUHLpP6hVocFd2