### PR TITLE
Add NETCONF lab — Cisco C8000V IOS XE (ncclient demo)

### DIFF
--- a/labs/devnet-netconf/README.md
+++ b/labs/devnet-netconf/README.md
@@ -1,0 +1,118 @@
+# Lab NETCONF — Cisco C8000V IOS XE / NETCONF Lab — Cisco C8000V IOS XE
+
+---
+
+## FR — Description
+
+Ce lab démontre l'automatisation réseau via **NETCONF/YANG** sur un routeur virtuel Cisco C8000V.
+
+| Paramètre | Valeur |
+|---|---|
+| Plateforme | Cisco C8000V IOS XE 17.15.04c |
+| Protocole | NETCONF (SSH port 830) |
+| Bibliothèque Python | ncclient 0.7.1 |
+| Modèles YANG | `ietf-interfaces`, `Cisco-IOS-XE-native` |
+
+### Opérations démontrées
+
+- **get interfaces** — récupère l'état opérationnel de toutes les interfaces via `ietf-interfaces`
+- **get-config OSPF** — extrait la configuration OSPF en XML via `Cisco-IOS-XE-native`
+
+### Prérequis
+
+```bash
+pip install ncclient==0.7.1
+```
+
+Variables d'environnement requises :
+
+```bash
+export DEVNET_HOST=<IP-HERE>
+export DEVNET_USER=<USERNAME-HERE>
+export DEVNET_PASS=<PASSWORD-HERE>
+```
+
+### Exécution
+
+```bash
+python netconf_get.py
+```
+
+---
+
+## EN — Description
+
+This lab demonstrates network automation via **NETCONF/YANG** on a Cisco C8000V virtual router.
+
+| Parameter | Value |
+|---|---|
+| Platform | Cisco C8000V IOS XE 17.15.04c |
+| Protocol | NETCONF (SSH port 830) |
+| Python library | ncclient 0.7.1 |
+| YANG models | `ietf-interfaces`, `Cisco-IOS-XE-native` |
+
+### Demonstrated operations
+
+- **get interfaces** — retrieves the operational state of all interfaces via `ietf-interfaces`
+- **get-config OSPF** — extracts OSPF configuration as XML via `Cisco-IOS-XE-native`
+
+### Prerequisites
+
+```bash
+pip install ncclient==0.7.1
+```
+
+Required environment variables:
+
+```bash
+export DEVNET_HOST=<IP-HERE>
+export DEVNET_USER=<USERNAME-HERE>
+export DEVNET_PASS=<PASSWORD-HERE>
+```
+
+### Run
+
+```bash
+python netconf_get.py
+```
+
+---
+
+## Output example / Exemple de sortie
+
+```xml
+=== GET interfaces (ietf-interfaces) ===
+<?xml version="1.0" encoding="UTF-8"?>
+<rpc-reply xmlns="urn:ietf:params:xml:ns:netconf:base:1.0">
+  <data>
+    <interfaces xmlns="urn:ietf:params:xml:ns:yang:ietf-interfaces">
+      <interface>
+        <name>GigabitEthernet1</name>
+        <type xmlns:ianaift="urn:ietf:params:xml:ns:yang:iana-if-type">
+          ianaift:ethernetCsmacd
+        </type>
+        <enabled>true</enabled>
+      </interface>
+    </interfaces>
+  </data>
+</rpc-reply>
+
+=== GET-CONFIG OSPF (Cisco-IOS-XE-native) ===
+<?xml version="1.0" encoding="UTF-8"?>
+<rpc-reply xmlns="urn:ietf:params:xml:ns:netconf:base:1.0">
+  <data>
+    <native xmlns="http://cisco.com/ns/yang/Cisco-IOS-XE-native">
+      <router>
+        <ospf xmlns="http://cisco.com/ns/yang/Cisco-IOS-XE-ospf">
+          <id>1</id>
+          <network>
+            <ip><NETWORK-HERE></ip>
+            <mask><MASK-HERE></mask>
+            <area><AREA-HERE></area>
+          </network>
+        </ospf>
+      </router>
+    </native>
+  </data>
+</rpc-reply>
+```

--- a/labs/devnet-netconf/netconf_get.py
+++ b/labs/devnet-netconf/netconf_get.py
@@ -1,0 +1,73 @@
+"""
+NETCONF lab — Cisco C8000V IOS XE 17.15.04c
+Demonstrates: get interfaces (ietf-interfaces) + get-config OSPF (Cisco-IOS-XE-native)
+Credentials via env vars: DEVNET_HOST, DEVNET_USER, DEVNET_PASS
+"""
+
+import os
+import sys
+from xml.dom.minidom import parseString
+
+from ncclient import manager
+
+NETCONF_PORT = 830
+
+FILTER_INTERFACES = """
+<filter>
+  <interfaces xmlns="urn:ietf:params:xml:ns:yang:ietf-interfaces"/>
+</filter>
+"""
+
+FILTER_OSPF = """
+<filter>
+  <native xmlns="http://cisco.com/ns/yang/Cisco-IOS-XE-native">
+    <router>
+      <ospf xmlns="http://cisco.com/ns/yang/Cisco-IOS-XE-ospf"/>
+    </router>
+  </native>
+</filter>
+"""
+
+
+def pretty(xml_str: str) -> str:
+    try:
+        return parseString(xml_str).toprettyxml(indent="  ")
+    except Exception:
+        return xml_str
+
+
+def get_credentials() -> tuple[str, str, str]:
+    host = os.environ.get("DEVNET_HOST")
+    user = os.environ.get("DEVNET_USER")
+    password = os.environ.get("DEVNET_PASS")
+    missing = [name for name, val in [("DEVNET_HOST", host), ("DEVNET_USER", user), ("DEVNET_PASS", password)] if not val]
+    if missing:
+        print(f"Error: missing environment variable(s): {', '.join(missing)}", file=sys.stderr)
+        sys.exit(1)
+    return host, user, password
+
+
+def main():
+    host, user, password = get_credentials()
+
+    with manager.connect(
+        host=host,
+        port=NETCONF_PORT,
+        username=user,
+        password=password,
+        hostkey_verify=False,
+        device_params={"name": "iosxe"},
+        look_for_keys=False,
+        allow_agent=False,
+    ) as conn:
+        print("=== GET interfaces (ietf-interfaces) ===")
+        response = conn.get(FILTER_INTERFACES)
+        print(pretty(str(response)))
+
+        print("=== GET-CONFIG OSPF (Cisco-IOS-XE-native) ===")
+        response = conn.get_config(source="running", filter=FILTER_OSPF)
+        print(pretty(str(response)))
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

- Adds `labs/devnet-netconf/` with bilingual README (FR/EN) documenting the Cisco C8000V IOS XE 17.15.04c / NETCONF port 830 setup
- Adds `netconf_get.py`: ncclient 0.7.1 script demonstrating `get` (ietf-interfaces) and `get-config` OSPF (Cisco-IOS-XE-native) with pretty XML output
- Credentials loaded securely from env vars `DEVNET_HOST`, `DEVNET_USER`, `DEVNET_PASS` — no secrets committed

## Test plan

- [ ] Set `DEVNET_HOST`, `DEVNET_USER`, `DEVNET_PASS` env vars pointing to a sandbox C8000V
- [ ] `pip install ncclient==0.7.1`
- [ ] `python labs/devnet-netconf/netconf_get.py` — verify two XML blocks printed
- [ ] Confirm error message when env vars are missing

https://claude.ai/code/session_011RsgT1nn8C6To9qYGWdvym