### PR TITLE
Add labs/devnet-bgp-ebgp — eBGP lab (AS65001 ↔ AS65002)

### DIFF
--- a/labs/devnet-bgp-ebgp/README.md
+++ b/labs/devnet-bgp-ebgp/README.md
@@ -1,0 +1,123 @@
+# Lab — BGP eBGP (pod01 ↔ pod02)
+
+## FR — Description
+
+Lab de routage BGP externe (eBGP) entre deux routeurs Cisco IOS-XE virtualisés.  
+Objectif : établir une adjacence BGP inter-AS, annoncer un préfixe loopback et vérifier l'AS-path sur le pair distant.
+
+### Topologie
+
+```
+  pod01                         pod02
+  AS65001                       AS65002
+  Lo0: 1.1.1.1/32               Lo0: 2.2.2.2/32
+  Gi0/0: 10.10.20.102/30  ----  Gi0/0: 10.10.20.103/30
+```
+
+### Paramètres BGP
+
+| Paramètre        | pod01           | pod02           |
+|------------------|-----------------|-----------------|
+| AS local         | 65001           | 65002           |
+| Router-ID        | 1.1.1.1         | 2.2.2.2         |
+| Loopback0        | 1.1.1.1/32      | 2.2.2.2/32      |
+| IP peering       | 10.10.20.102    | 10.10.20.103    |
+| Peer déclaré     | 10.10.20.103    | 10.10.20.102    |
+| Remote-AS        | 65002           | 65001           |
+
+### État attendu
+
+- Adjacence eBGP : **Established**
+- pod02 apprend **1.1.1.1/32** via `10.10.20.102` (next-hop)
+- AS-path visible sur pod02 : `65001`
+
+### Commandes de vérification
+
+```bash
+# Adjacence
+show bgp summary
+
+# Table BGP complète
+show ip bgp
+
+# Préfixe spécifique avec AS-path
+show ip bgp 1.1.1.1/32
+
+# Routes reçues du pair
+show ip bgp neighbors 10.10.20.102 received-routes
+```
+
+### Sortie attendue sur pod02
+
+```
+pod02# show ip bgp
+BGP table version is 3, local router ID is 2.2.2.2
+Status codes: s suppressed, d damped, h history, * valid, > best, i internal
+Origin codes: i - IGP, e - EGP, ? - incomplete
+
+   Network          Next Hop            Metric LocPrf Weight Path
+*> 1.1.1.1/32       10.10.20.102             0             0 65001 i
+*> 2.2.2.2/32       0.0.0.0                  0         32768 i
+```
+
+---
+
+## EN — Description
+
+External BGP (eBGP) routing lab between two virtualised Cisco IOS-XE routers.  
+Goal: bring up a BGP inter-AS adjacency, advertise a loopback prefix, and verify the AS-path on the remote peer.
+
+### Topology
+
+```
+  pod01                         pod02
+  AS65001                       AS65002
+  Lo0: 1.1.1.1/32               Lo0: 2.2.2.2/32
+  Gi0/0: 10.10.20.102/30  ----  Gi0/0: 10.10.20.103/30
+```
+
+### BGP Parameters
+
+| Parameter        | pod01           | pod02           |
+|------------------|-----------------|-----------------|
+| Local AS         | 65001           | 65002           |
+| Router-ID        | 1.1.1.1         | 2.2.2.2         |
+| Loopback0        | 1.1.1.1/32      | 2.2.2.2/32      |
+| Peering IP       | 10.10.20.102    | 10.10.20.103    |
+| Declared peer    | 10.10.20.103    | 10.10.20.102    |
+| Remote-AS        | 65002           | 65001           |
+
+### Expected State
+
+- eBGP adjacency: **Established**
+- pod02 learns **1.1.1.1/32** via `10.10.20.102` (next-hop)
+- AS-path visible on pod02: `65001`
+
+### Verification Commands
+
+```bash
+# Adjacency
+show bgp summary
+
+# Full BGP table
+show ip bgp
+
+# Specific prefix with AS-path
+show ip bgp 1.1.1.1/32
+
+# Routes received from peer
+show ip bgp neighbors 10.10.20.102 received-routes
+```
+
+### Expected Output on pod02
+
+```
+pod02# show ip bgp
+BGP table version is 3, local router ID is 2.2.2.2
+Status codes: s suppressed, d damped, h history, * valid, > best, i internal
+Origin codes: i - IGP, e - EGP, ? - incomplete
+
+   Network          Next Hop            Metric LocPrf Weight Path
+*> 1.1.1.1/32       10.10.20.102             0             0 65001 i
+*> 2.2.2.2/32       0.0.0.0                  0         32768 i
+```

--- a/labs/devnet-bgp-ebgp/bgp_config.txt
+++ b/labs/devnet-bgp-ebgp/bgp_config.txt
@@ -1,0 +1,72 @@
+! ============================================================
+! BGP eBGP Lab — pod01 (AS65001) + pod02 (AS65002)
+! Peering link: 10.10.20.102/30 <-> 10.10.20.103/30
+! ============================================================
+
+! ============================================================
+! pod01 — AS65001
+! ============================================================
+
+hostname pod01
+
+interface Loopback0
+ ip address 1.1.1.1 255.255.255.255
+!
+
+interface GigabitEthernet0/0
+ ip address 10.10.20.102 255.255.255.252
+ no shutdown
+!
+
+router bgp 65001
+ bgp router-id 1.1.1.1
+ bgp log-neighbor-changes
+ !
+ neighbor 10.10.20.103 remote-as 65002
+ neighbor 10.10.20.103 description eBGP_TO_pod02
+ !
+ address-family ipv4
+  network 1.1.1.1 mask 255.255.255.255
+  neighbor 10.10.20.103 activate
+ exit-address-family
+!
+
+! ============================================================
+! pod02 — AS65002
+! ============================================================
+
+hostname pod02
+
+interface Loopback0
+ ip address 2.2.2.2 255.255.255.255
+!
+
+interface GigabitEthernet0/0
+ ip address 10.10.20.103 255.255.255.252
+ no shutdown
+!
+
+router bgp 65002
+ bgp router-id 2.2.2.2
+ bgp log-neighbor-changes
+ !
+ neighbor 10.10.20.102 remote-as 65001
+ neighbor 10.10.20.102 description eBGP_TO_pod01
+ !
+ address-family ipv4
+  network 2.2.2.2 mask 255.255.255.255
+  neighbor 10.10.20.102 activate
+ exit-address-family
+!
+
+! ============================================================
+! Verification — run on pod02
+! ============================================================
+!
+! show bgp summary
+! show ip bgp
+! show ip bgp 1.1.1.1/32
+! show ip bgp neighbors 10.10.20.102 received-routes
+!
+! Expected: 1.1.1.1/32 learned with next-hop 10.10.20.102, AS-path 65001
+! ============================================================


### PR DESCRIPTION
## Summary

- Creates `labs/devnet-bgp-ebgp/README.md` — bilingual FR/EN doc covering topology, BGP parameters table, expected adjacency state, verification commands, and sample `show ip bgp` output on pod02
- Creates `labs/devnet-bgp-ebgp/bgp_config.txt` — full Cisco IOS-XE config for pod01 (AS65001, 1.1.1.1) and pod02 (AS65002, 2.2.2.2), eBGP peering over 10.10.20.102/103

## Test plan

- [ ] Verify README renders correctly (tables, code blocks, ASCII topology)
- [ ] Apply `bgp_config.txt` to virtual pods and confirm `show bgp summary` shows Established
- [ ] Confirm pod02 learns 1.1.1.1/32 with AS-path `65001` via `show ip bgp`

https://claude.ai/code/session_014azDXUcAEHHX7mEpLYqB4b