### PR TITLE
Add labs/devnet-bgp-attributes — BGP Local-Preference & MED lab

### DIFF
--- a/labs/devnet-bgp-attributes/README.md
+++ b/labs/devnet-bgp-attributes/README.md
@@ -1,0 +1,171 @@
+# Lab — BGP Attributes : Local-Preference & MED
+
+## FR — Description
+
+Lab de manipulation des attributs BGP via route-maps sur deux routeurs Cisco IOS-XE.  
+Objectif : configurer un Local-Preference entrant sur pod01 et un MED sortant sur pod02, puis vérifier le résultat dans la table BGP.
+
+### Topologie
+
+```
+  pod01                         pod02
+  AS65001                       AS65002
+  Lo0: 1.1.1.1/32               Lo0: 2.2.2.2/32
+  Gi0/0: 10.10.20.102/30  ----  Gi0/0: 10.10.20.103/30
+```
+
+### Attributs configurés
+
+| Attribut        | Valeur | Où configuré | Direction  | Route-map         |
+|-----------------|--------|--------------|------------|-------------------|
+| Local-Preference | 200   | pod01        | in (depuis pod02) | SET-LOCAL-PREF |
+| MED             | 100    | pod02        | out (vers pod01)  | SET-MED        |
+
+### Local-Preference (LOCAL-PREF)
+
+- **Scope** : interne à l'AS, non propagé aux peers eBGP
+- **Usage** : influencer le chemin de sortie de l'AS pour les routes apprises
+- **Valeur par défaut** : 100 — une valeur **plus élevée** est préférée
+- **Ici** : pod01 applique `local-preference 200` aux routes reçues de pod02 → préférence renforcée pour `2.2.2.2/32`
+
+### MED (Multi-Exit Discriminator)
+
+- **Scope** : propagé au peer eBGP direct, suggère le chemin d'entrée préféré dans l'AS local
+- **Usage** : influencer le chemin d'entrée vers l'AS qui annonce le MED
+- **Valeur par défaut** : 0 — une valeur **plus basse** est préférée
+- **Ici** : pod02 envoie `metric 100` sur `2.2.2.2/32` vers pod01
+
+### Résultat attendu sur pod01
+
+```
+pod01# show ip bgp
+BGP table version is 4, local router ID is 1.1.1.1
+Status codes: s suppressed, d damped, h history, * valid, > best, i internal
+Origin codes: i - IGP, e - EGP, ? - incomplete
+
+   Network          Next Hop            Metric LocPrf Weight Path
+*> 1.1.1.1/32       0.0.0.0                  0         32768 i
+*> 2.2.2.2/32       10.10.20.103           100    200      0 65002 i
+```
+
+- `Metric=100` → MED positionné par pod02 via `SET-MED`
+- `LocPrf=200` → Local-Preference positionné par pod01 via `SET-LOCAL-PREF`
+
+### Commandes de vérification
+
+```bash
+# Table BGP complète
+show ip bgp
+
+# Détail du préfixe avec tous les attributs
+show ip bgp 2.2.2.2/32
+
+# Route-maps appliquées
+show route-map SET-LOCAL-PREF
+show route-map SET-MED
+
+# Vérification du peer BGP
+show bgp summary
+show ip bgp neighbors 10.10.20.103 received-routes
+```
+
+### Sortie détaillée attendue sur pod01
+
+```
+pod01# show ip bgp 2.2.2.2/32
+BGP routing table entry for 2.2.2.2/32, version 3
+Paths: (1 available, best #1, table default)
+  Advertised to update-groups:
+     1
+  Refresh Epoch 1
+  65002
+    10.10.20.103 from 10.10.20.103 (2.2.2.2)
+      Origin IGP, metric 100, localpref 200, valid, external, best
+      rx pathid: 0, tx pathid: 0x0
+```
+
+---
+
+## EN — Description
+
+BGP attribute manipulation lab using route-maps on two Cisco IOS-XE routers.  
+Goal: configure an inbound Local-Preference on pod01 and an outbound MED on pod02, then verify the result in the BGP table.
+
+### Topology
+
+```
+  pod01                         pod02
+  AS65001                       AS65002
+  Lo0: 1.1.1.1/32               Lo0: 2.2.2.2/32
+  Gi0/0: 10.10.20.102/30  ----  Gi0/0: 10.10.20.103/30
+```
+
+### Configured Attributes
+
+| Attribute        | Value | Configured on | Direction        | Route-map         |
+|------------------|-------|---------------|------------------|-------------------|
+| Local-Preference | 200   | pod01         | in (from pod02)  | SET-LOCAL-PREF    |
+| MED              | 100   | pod02         | out (to pod01)   | SET-MED           |
+
+### Local-Preference (LOCAL-PREF)
+
+- **Scope**: internal to the AS, not propagated to eBGP peers
+- **Usage**: influence the AS exit path for learned routes
+- **Default**: 100 — a **higher** value is preferred
+- **Here**: pod01 applies `local-preference 200` to routes received from pod02 → stronger preference for `2.2.2.2/32`
+
+### MED (Multi-Exit Discriminator)
+
+- **Scope**: propagated to the direct eBGP peer, suggests the preferred entry path into the local AS
+- **Usage**: influence the entry path into the AS that advertises the MED
+- **Default**: 0 — a **lower** value is preferred
+- **Here**: pod02 sends `metric 100` on `2.2.2.2/32` toward pod01
+
+### Expected Result on pod01
+
+```
+pod01# show ip bgp
+BGP table version is 4, local router ID is 1.1.1.1
+Status codes: s suppressed, d damped, h history, * valid, > best, i internal
+Origin codes: i - IGP, e - EGP, ? - incomplete
+
+   Network          Next Hop            Metric LocPrf Weight Path
+*> 1.1.1.1/32       0.0.0.0                  0         32768 i
+*> 2.2.2.2/32       10.10.20.103           100    200      0 65002 i
+```
+
+- `Metric=100` → MED set by pod02 via `SET-MED`
+- `LocPrf=200` → Local-Preference set by pod01 via `SET-LOCAL-PREF`
+
+### Verification Commands
+
+```bash
+# Full BGP table
+show ip bgp
+
+# Prefix detail with all attributes
+show ip bgp 2.2.2.2/32
+
+# Applied route-maps
+show route-map SET-LOCAL-PREF
+show route-map SET-MED
+
+# BGP peer check
+show bgp summary
+show ip bgp neighbors 10.10.20.103 received-routes
+```
+
+### Expected Detailed Output on pod01
+
+```
+pod01# show ip bgp 2.2.2.2/32
+BGP routing table entry for 2.2.2.2/32, version 3
+Paths: (1 available, best #1, table default)
+  Advertised to update-groups:
+     1
+  Refresh Epoch 1
+  65002
+    10.10.20.103 from 10.10.20.103 (2.2.2.2)
+      Origin IGP, metric 100, localpref 200, valid, external, best
+      rx pathid: 0, tx pathid: 0x0
+```

--- a/labs/devnet-bgp-attributes/bgp_attributes_config.txt
+++ b/labs/devnet-bgp-attributes/bgp_attributes_config.txt
@@ -1,0 +1,113 @@
+! ============================================================
+! BGP Attributes Lab — Local-Preference & MED
+! pod01 (AS65001) + pod02 (AS65002)
+! Peering link: 10.10.20.102/30 <-> 10.10.20.103/30
+! ============================================================
+
+! ============================================================
+! pod01 — AS65001
+! Local-Preference 200 applied inbound from pod02
+! Route-map: SET-LOCAL-PREF
+! ============================================================
+
+hostname pod01
+
+interface Loopback0
+ ip address 1.1.1.1 255.255.255.255
+!
+
+interface GigabitEthernet0/0
+ ip address 10.10.20.102 255.255.255.252
+ no shutdown
+!
+
+!
+! Route-map: set local-preference 200 on all routes received from pod02
+!
+route-map SET-LOCAL-PREF permit 10
+ set local-preference 200
+!
+
+router bgp 65001
+ bgp router-id 1.1.1.1
+ bgp log-neighbor-changes
+ !
+ neighbor 10.10.20.103 remote-as 65002
+ neighbor 10.10.20.103 description eBGP_TO_pod02
+ !
+ address-family ipv4
+  network 1.1.1.1 mask 255.255.255.255
+  neighbor 10.10.20.103 activate
+  ! Apply local-pref route-map inbound
+  neighbor 10.10.20.103 route-map SET-LOCAL-PREF in
+  ! Accept inbound soft-reconfig for verification
+  neighbor 10.10.20.103 soft-reconfiguration inbound
+ exit-address-family
+!
+
+! ============================================================
+! pod02 — AS65002
+! MED 100 applied outbound toward pod01
+! Route-map: SET-MED
+! ============================================================
+
+hostname pod02
+
+interface Loopback0
+ ip address 2.2.2.2 255.255.255.255
+!
+
+interface GigabitEthernet0/0
+ ip address 10.10.20.103 255.255.255.252
+ no shutdown
+!
+
+!
+! Route-map: set MED (metric) 100 on all routes sent to pod01
+!
+route-map SET-MED permit 10
+ set metric 100
+!
+
+router bgp 65002
+ bgp router-id 2.2.2.2
+ bgp log-neighbor-changes
+ !
+ neighbor 10.10.20.102 remote-as 65001
+ neighbor 10.10.20.102 description eBGP_TO_pod01
+ !
+ address-family ipv4
+  network 2.2.2.2 mask 255.255.255.255
+  neighbor 10.10.20.102 activate
+  ! Apply MED route-map outbound
+  neighbor 10.10.20.102 route-map SET-MED out
+ exit-address-family
+!
+
+! ============================================================
+! Verification — run on pod01
+! ============================================================
+!
+! show ip bgp
+! Expected: 2.2.2.2/32  Metric=100  LocPrf=200  Path=65002
+!
+! show ip bgp 2.2.2.2/32
+! Expected: metric 100, localpref 200, valid, external, best
+!
+! show route-map SET-LOCAL-PREF
+! show ip bgp neighbors 10.10.20.103 received-routes
+!
+! ============================================================
+! Verification — run on pod02
+! ============================================================
+!
+! show route-map SET-MED
+! show ip bgp neighbors 10.10.20.102 advertised-routes
+!
+! ============================================================
+! BGP soft reset after route-map changes
+! ============================================================
+!
+! clear ip bgp 10.10.20.103 soft in   ! on pod01 — re-apply inbound policy
+! clear ip bgp 10.10.20.102 soft out  ! on pod02 — re-send with new MED
+! ============================================================


### PR DESCRIPTION
## Summary

- Creates `labs/devnet-bgp-attributes/README.md` — bilingual FR/EN doc: topology, attribute table (Local-Pref 200 inbound on pod01, MED 100 outbound on pod02), expected `show ip bgp` output showing `2.2.2.2/32` with `Metric=100 LocPrf=200`, detailed `show ip bgp 2.2.2.2/32` path output, soft-reset commands
- Creates `labs/devnet-bgp-attributes/bgp_attributes_config.txt` — full IOS-XE config: route-map `SET-LOCAL-PREF` applied `in` on pod01, route-map `SET-MED` applied `out` on pod02, `soft-reconfiguration inbound` for verification

## Test plan

- [ ] Verify README renders correctly (tables, code blocks, ASCII topology)
- [ ] Apply config to virtual pods and confirm `show ip bgp` on pod01 shows `2.2.2.2/32` with `Metric=100` and `LocPrf=200`
- [ ] Confirm `show ip bgp 2.2.2.2/32` shows `metric 100, localpref 200, valid, external, best`

https://claude.ai/code/session_014azDXUcAEHHX7mEpLYqB4b