### PR TITLE
Add labs/devnet-bgp-filtering — BGP inbound prefix-list filtering lab

### DIFF
--- a/labs/devnet-bgp-filtering/README.md
+++ b/labs/devnet-bgp-filtering/README.md
@@ -1,0 +1,165 @@
+# Lab — BGP Filtering : prefix-list entrant sur pod01
+
+## FR — Description
+
+Lab de filtrage BGP par prefix-list sur un routeur Cisco IOS-XE.  
+Objectif : bloquer l'annonce `10.10.20.0/24` reçue de pod02 sur pod01, en appliquant une prefix-list en entrée, tout en laissant passer les autres préfixes.
+
+### Topologie
+
+```
+  pod01                         pod02
+  AS65001                       AS65002
+  Lo0: 1.1.1.1/32               Lo0: 2.2.2.2/32
+  Gi0/0: 10.10.20.102/30  ----  Gi0/0: 10.10.20.103/30
+```
+
+### Prefix-list FILTER-IN
+
+```
+ip prefix-list FILTER-IN seq 5  deny   10.10.20.0/24
+ip prefix-list FILTER-IN seq 10 permit 0.0.0.0/0 le 32
+```
+
+| Séquence | Action  | Préfixe          | Effet                               |
+|----------|---------|------------------|-------------------------------------|
+| 5        | deny    | 10.10.20.0/24    | Bloque exactement ce préfixe        |
+| 10       | permit  | 0.0.0.0/0 le 32  | Autorise tous les autres préfixes   |
+
+> **Important** : une prefix-list a un `deny any` implicite en fin de liste.  
+> La séquence 10 (`permit 0.0.0.0/0 le 32`) est indispensable pour ne pas bloquer tous les préfixes restants.
+
+### Application sur le neighbor
+
+```
+neighbor 10.10.20.103 prefix-list FILTER-IN in
+```
+
+La prefix-list est appliquée **en entrée** sur pod01, côté peer pod02.  
+Pod02 continue d'annoncer `10.10.20.0/24`, mais pod01 la rejette à la réception.
+
+### Résultat attendu sur pod01
+
+**Avant filtrage** (sans prefix-list) :
+```
+pod01# show ip bgp
+   Network          Next Hop            Metric LocPrf Weight Path
+*> 1.1.1.1/32       0.0.0.0                  0         32768 i
+*> 2.2.2.2/32       10.10.20.103             0             0 65002 i
+*> 10.10.20.0/24    10.10.20.103             0             0 65002 ?
+```
+
+**Après filtrage** (avec FILTER-IN appliquée) :
+```
+pod01# show ip bgp
+   Network          Next Hop            Metric LocPrf Weight Path
+*> 1.1.1.1/32       0.0.0.0                  0         32768 i
+*> 2.2.2.2/32       10.10.20.103             0             0 65002 i
+```
+
+`10.10.20.0/24` a disparu de la table BGP de pod01 — filtrée en entrée.
+
+### Commandes de vérification
+
+```bash
+# Table BGP — vérifier l'absence de 10.10.20.0/24
+show ip bgp
+
+# Routes reçues avant filtrage (soft-reconfig requis)
+show ip bgp neighbors 10.10.20.103 received-routes
+
+# Routes acceptées après filtrage
+show ip bgp neighbors 10.10.20.103 routes
+
+# Vérifier la prefix-list
+show ip prefix-list FILTER-IN
+
+# Vérifier l'application sur le neighbor
+show ip bgp neighbors 10.10.20.103 | include prefix-list
+
+# Appliquer le filtrage sans reset de session
+clear ip bgp 10.10.20.103 soft in
+```
+
+---
+
+## EN — Description
+
+BGP filtering lab using a prefix-list on a Cisco IOS-XE router.  
+Goal: block the `10.10.20.0/24` advertisement received from pod02 on pod01 by applying an inbound prefix-list, while allowing all other prefixes through.
+
+### Topology
+
+```
+  pod01                         pod02
+  AS65001                       AS65002
+  Lo0: 1.1.1.1/32               Lo0: 2.2.2.2/32
+  Gi0/0: 10.10.20.102/30  ----  Gi0/0: 10.10.20.103/30
+```
+
+### Prefix-list FILTER-IN
+
+```
+ip prefix-list FILTER-IN seq 5  deny   10.10.20.0/24
+ip prefix-list FILTER-IN seq 10 permit 0.0.0.0/0 le 32
+```
+
+| Sequence | Action  | Prefix           | Effect                              |
+|----------|---------|------------------|-------------------------------------|
+| 5        | deny    | 10.10.20.0/24    | Blocks this exact prefix            |
+| 10       | permit  | 0.0.0.0/0 le 32  | Allows all other prefixes           |
+
+> **Important**: a prefix-list has an implicit `deny any` at the end.  
+> Sequence 10 (`permit 0.0.0.0/0 le 32`) is required to avoid blocking all remaining prefixes.
+
+### Applied to Neighbor
+
+```
+neighbor 10.10.20.103 prefix-list FILTER-IN in
+```
+
+The prefix-list is applied **inbound** on pod01, toward peer pod02.  
+Pod02 still advertises `10.10.20.0/24`, but pod01 rejects it upon receipt.
+
+### Expected Result on pod01
+
+**Before filtering** (no prefix-list):
+```
+pod01# show ip bgp
+   Network          Next Hop            Metric LocPrf Weight Path
+*> 1.1.1.1/32       0.0.0.0                  0         32768 i
+*> 2.2.2.2/32       10.10.20.103             0             0 65002 i
+*> 10.10.20.0/24    10.10.20.103             0             0 65002 ?
+```
+
+**After filtering** (FILTER-IN applied):
+```
+pod01# show ip bgp
+   Network          Next Hop            Metric LocPrf Weight Path
+*> 1.1.1.1/32       0.0.0.0                  0         32768 i
+*> 2.2.2.2/32       10.10.20.103             0             0 65002 i
+```
+
+`10.10.20.0/24` is gone from pod01's BGP table — filtered inbound.
+
+### Verification Commands
+
+```bash
+# BGP table — confirm 10.10.20.0/24 is absent
+show ip bgp
+
+# Routes received before filtering (requires soft-reconfig)
+show ip bgp neighbors 10.10.20.103 received-routes
+
+# Routes accepted after filtering
+show ip bgp neighbors 10.10.20.103 routes
+
+# Check the prefix-list
+show ip prefix-list FILTER-IN
+
+# Check prefix-list applied to neighbor
+show ip bgp neighbors 10.10.20.103 | include prefix-list
+
+# Apply filtering without resetting the session
+clear ip bgp 10.10.20.103 soft in
+```

--- a/labs/devnet-bgp-filtering/bgp_filtering_config.txt
+++ b/labs/devnet-bgp-filtering/bgp_filtering_config.txt
@@ -1,0 +1,101 @@
+! ============================================================
+! BGP Filtering Lab — prefix-list FILTER-IN on pod01
+! pod01 (AS65001) + pod02 (AS65002)
+! Peering link: 10.10.20.102/30 <-> 10.10.20.103/30
+! ============================================================
+
+! ============================================================
+! pod01 — AS65001
+! Inbound prefix-list: deny 10.10.20.0/24, permit all others
+! ============================================================
+
+hostname pod01
+
+interface Loopback0
+ ip address 1.1.1.1 255.255.255.255
+!
+
+interface GigabitEthernet0/0
+ ip address 10.10.20.102 255.255.255.252
+ no shutdown
+!
+
+!
+! Prefix-list FILTER-IN:
+!   seq 5  — deny exactly 10.10.20.0/24
+!   seq 10 — permit everything else (implicit deny any at end of list)
+!
+ip prefix-list FILTER-IN seq 5  deny   10.10.20.0/24
+ip prefix-list FILTER-IN seq 10 permit 0.0.0.0/0 le 32
+
+router bgp 65001
+ bgp router-id 1.1.1.1
+ bgp log-neighbor-changes
+ !
+ neighbor 10.10.20.103 remote-as 65002
+ neighbor 10.10.20.103 description eBGP_TO_pod02
+ !
+ address-family ipv4
+  network 1.1.1.1 mask 255.255.255.255
+  neighbor 10.10.20.103 activate
+  ! Apply prefix-list inbound — filters 10.10.20.0/24 from pod02
+  neighbor 10.10.20.103 prefix-list FILTER-IN in
+  ! soft-reconfiguration required for received-routes verification
+  neighbor 10.10.20.103 soft-reconfiguration inbound
+ exit-address-family
+!
+
+! ============================================================
+! pod02 — AS65002
+! Announces both 2.2.2.2/32 and 10.10.20.0/24
+! pod01 will filter 10.10.20.0/24 on reception
+! ============================================================
+
+hostname pod02
+
+interface Loopback0
+ ip address 2.2.2.2 255.255.255.255
+!
+
+interface GigabitEthernet0/0
+ ip address 10.10.20.103 255.255.255.252
+ no shutdown
+!
+
+router bgp 65002
+ bgp router-id 2.2.2.2
+ bgp log-neighbor-changes
+ !
+ neighbor 10.10.20.102 remote-as 65001
+ neighbor 10.10.20.102 description eBGP_TO_pod01
+ !
+ address-family ipv4
+  ! Announce loopback
+  network 2.2.2.2 mask 255.255.255.255
+  ! Announce peering subnet — will be filtered by pod01
+  network 10.10.20.100 mask 255.255.255.252
+  neighbor 10.10.20.102 activate
+ exit-address-family
+!
+
+! ============================================================
+! Verification — run on pod01
+! ============================================================
+!
+! show ip prefix-list FILTER-IN
+!
+! show ip bgp neighbors 10.10.20.103 received-routes
+! (shows 10.10.20.0/24 as received but not installed)
+!
+! show ip bgp neighbors 10.10.20.103 routes
+! (shows only 2.2.2.2/32 — 10.10.20.0/24 filtered out)
+!
+! show ip bgp
+! Expected: only 1.1.1.1/32 and 2.2.2.2/32 — no 10.10.20.0/24
+!
+! ============================================================
+! Apply filtering without dropping session
+! ============================================================
+!
+! clear ip bgp 10.10.20.103 soft in
+! ============================================================


### PR DESCRIPTION
## Summary

- Creates `labs/devnet-bgp-filtering/README.md` — bilingual FR/EN doc: prefix-list `FILTER-IN` table (deny `10.10.20.0/24` seq 5, permit all seq 10), implicit deny-any note, before/after `show ip bgp` comparison showing `10.10.20.0/24` disappears, `received-routes` vs `routes` distinction, `clear ip bgp soft in` usage
- Creates `labs/devnet-bgp-filtering/bgp_filtering_config.txt` — full IOS-XE config: `ip prefix-list FILTER-IN` + `neighbor 10.10.20.103 prefix-list FILTER-IN in` on pod01, pod02 announcing both `2.2.2.2/32` and `10.10.20.0/24`

## Test plan

- [ ] Verify README renders correctly (tables, code blocks, before/after outputs)
- [ ] Apply config to virtual pods and confirm `show ip bgp` on pod01 shows only `1.1.1.1/32` and `2.2.2.2/32` — no `10.10.20.0/24`
- [ ] Confirm `show ip bgp neighbors 10.10.20.103 received-routes` still shows `10.10.20.0/24` (received but filtered)

https://claude.ai/code/session_014azDXUcAEHHX7mEpLYqB4b