### PR TITLE
fix(ci): delete branch inline after auto-merge + bulk cleanup workflow

### DIFF
--- a/.github/workflows/auto-merge.yml
+++ b/.github/workflows/auto-merge.yml
@@ -17,14 +17,14 @@ jobs:
     if: startsWith(github.head_ref, 'claude/')
 
     steps:
-      - name: Merge PR via GitHub API
+      - name: Merge PR and delete branch
         uses: actions/github-script@v7
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |
             const pr = context.payload.pull_request;
             if (pr.state === 'closed') {
-              console.log(`PR #${pr.number} is already closed — skipping merge.`);
+              console.log(`PR #${pr.number} is already closed — skipping.`);
               return;
             }
             console.log(`Merging PR #${pr.number}: ${pr.title}`);
@@ -41,7 +41,20 @@ jobs:
             } catch (err) {
               if (err.status === 405 || err.status === 409) {
                 console.log(`Merge skipped (${err.status}): ${err.message}`);
-              } else {
-                throw err;
+                return;
               }
+              throw err;
+            }
+            // Delete branch in the same step — GITHUB_TOKEN blocks downstream
+            // pull_request events so a separate delete workflow would never fire.
+            const branch = pr.head.ref;
+            try {
+              await github.rest.git.deleteRef({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                ref: `heads/${branch}`
+              });
+              console.log(`Deleted branch: ${branch}`);
+            } catch (err) {
+              console.log(`Could not delete branch ${branch}: ${err.message}`);
             }

--- a/.github/workflows/delete-merged-claude-branches.yml
+++ b/.github/workflows/delete-merged-claude-branches.yml
@@ -1,0 +1,36 @@
+name: Delete merged claude/* branches
+
+on:
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+jobs:
+  cleanup:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Delete merged claude/* branches
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          git fetch --all --prune
+          DELETED=0
+          KEPT=0
+          for branch in $(git branch -r | grep 'origin/claude/' | sed 's|  origin/||' | tr -d ' '); do
+            AHEAD=$(git log "origin/main..origin/${branch}" --oneline 2>/dev/null | wc -l | tr -d ' ')
+            if [ "$AHEAD" = "0" ]; then
+              git push origin --delete "$branch" && echo "Deleted: $branch" && DELETED=$((DELETED+1)) || echo "Failed: $branch"
+            else
+              echo "Kept ($AHEAD commits ahead): $branch"
+              KEPT=$((KEPT+1))
+            fi
+          done
+          echo ""
+          echo "Done: $DELETED deleted, $KEPT kept."


### PR DESCRIPTION
## Root cause (different from the 3 other repos)

The existing `delete-merged-branches.yml` had correct triggers (`pull_request [closed]` + `merged == true`) — but **never fired** because `auto-merge.yml` merges PRs via `GITHUB_TOKEN`. GitHub deliberately blocks downstream workflow events triggered by `GITHUB_TOKEN` to prevent infinite loops. So the delete workflow was never invoked after auto-merges.

## Changes

### `auto-merge.yml` — delete branch inline after merge
After the squash-merge succeeds, the same step immediately calls `deleteRef` to remove the head branch. Since it runs in the same job as the merge, there is no downstream event dependency.

### `delete-merged-claude-branches.yml` — new bulk cleanup
Triggered on `push: branches: [main]` (fires on **manual** merges, which bypass the GITHUB_TOKEN restriction) and `workflow_dispatch` (manual runs from the GitHub UI).

## Effect on merge
This PR will be **manually merged** by the repo owner — so the `push: branches: [main]` trigger on `delete-merged-claude-branches.yml` **will fire** and purge all **30 existing orphaned** `claude/*` branches in one pass.

## Going forward
- Auto-merged PRs → branch deleted inline by `auto-merge.yml`
- Manually merged PRs → branch deleted by `delete-merged-branches.yml` (unchanged, already correct)
- Bulk cleanup anytime → `workflow_dispatch` on `delete-merged-claude-branches.yml`