### PR TITLE
fix: add missing skill stubs and complete .gitignore

### DIFF
--- a/.claude/skills/changelog-generator.md
+++ b/.claude/skills/changelog-generator.md
@@ -1,0 +1,35 @@
+# changelog-generator
+
+Generate a structured CHANGELOG entry from recent git commits.
+
+## Usage
+
+```
+/changelog-generator [version]
+```
+
+## Steps
+
+1. Run `git log --oneline <range>` to collect commits since the last tag or provided range.
+2. Group commits by type: `feat`, `fix`, `docs`, `chore`, `refactor`.
+3. Format the output as a Keep-a-Changelog section:
+
+```markdown
+## [<version>] - YYYY-MM-DD
+
+### Added
+- ...
+
+### Fixed
+- ...
+
+### Changed
+- ...
+```
+
+4. Print the section to stdout; do **not** write to `CHANGELOG.md` automatically — let the user review first.
+
+## Notes
+
+- Skip merge commits and bot commits.
+- Use placeholders (`<version>`, `<date>`) when not supplied.

--- a/.claude/skills/sanitize.md
+++ b/.claude/skills/sanitize.md
@@ -1,0 +1,32 @@
+# sanitize
+
+Scan staged or committed files for secrets and sensitive data before pushing.
+
+## Usage
+
+```
+/sanitize [path]
+```
+
+## Steps
+
+1. Search the target path (default: entire repo) for patterns that indicate secrets:
+   - Passwords / credentials (`password`, `passwd`, `secret`)
+   - API keys and tokens (long hex or base64 strings, `api_key`, `token`)
+   - Private keys (`-----BEGIN … PRIVATE KEY-----`)
+   - Real IP addresses of production equipment
+   - Personal contact information (email, phone)
+
+2. Report each finding with file path, line number, and the matched pattern.
+
+3. For each finding, suggest the correct placeholder:
+   - Passwords → `<PASSWORD-HERE>`
+   - Tokens / keys → `<TOKEN-HERE>`
+   - IPs → `<IP-HERE>`
+
+4. Do **not** auto-fix — present findings and let the user decide.
+
+## Notes
+
+- Follows the security rules in `CLAUDE.md`.
+- False positives (e.g., example placeholders) can be ignored after review.

--- a/.claude/skills/subagent-driven-development.md
+++ b/.claude/skills/subagent-driven-development.md
@@ -1,0 +1,29 @@
+# subagent-driven-development
+
+Decompose a complex task into parallel sub-agents for faster, isolated execution.
+
+## Usage
+
+```
+/subagent-driven-development <task description>
+```
+
+## Steps
+
+1. **Decompose** — Break the task into independent sub-tasks (research, implementation, tests, docs).
+2. **Spawn agents** — Launch each sub-task as a separate `Agent` tool call in a single message so they run concurrently.
+3. **Collect results** — Wait for all agents to finish; gather their outputs.
+4. **Synthesize** — Integrate the results, resolve conflicts, and produce the final deliverable.
+5. **Report** — Summarize what each agent did and what was merged.
+
+## Guidelines
+
+- Use `subagent_type: "Explore"` for read-only research agents.
+- Use `subagent_type: "general-purpose"` for implementation agents.
+- Keep agent prompts self-contained — each agent has no memory of the conversation.
+- Never delegate security-sensitive operations to sub-agents without explicit user approval.
+
+## Notes
+
+- Best suited for tasks with ≥ 3 independent work streams.
+- For sequential tasks, use a single agent or chain calls instead.

--- a/.gitignore
+++ b/.gitignore
@@ -12,9 +12,16 @@ __pycache__/
 # OS
 .DS_Store
 Thumbs.db
+desktop.ini
+
+# Editor
+.vscode/
+*.swp
+*~
 
 # Logs
 *.log
+npm-debug.log
 
 # Node
 node_modules/


### PR DESCRIPTION
## Summary

- Create `.claude/skills/` with three missing skill stubs: `changelog-generator`, `sanitize`, and `subagent-driven-development`
- Complete `.gitignore` with patterns flagged during audit: `.vscode/`, `*.swp`, `*~`, `desktop.ini`, `npm-debug.log`

## Test plan

- [ ] Verify `.claude/skills/` contains all three `.md` files with correct content
- [ ] Verify `.gitignore` now includes all previously missing patterns
- [ ] Confirm no secrets or sensitive data introduced

https://claude.ai/code/session_014j9iFYfe1qCyEJMkVk67eW