### PR TITLE
feat(labs): MPLS L3VPN lab — VRF CLIENT_A, LDP, MP-BGP VPNv4 on Cat8k

### DIFF
--- a/labs/devnet-mpls-l3vpn/README.md
+++ b/labs/devnet-mpls-l3vpn/README.md
@@ -1,0 +1,177 @@
+# Lab — MPLS L3VPN (VRF CLIENT_A on Cat8k)
+
+---
+
+## FR — Description
+
+Simulation d'un réseau MPLS L3VPN sur un seul équipement Cisco Catalyst 8000 (IOS-XE).  
+L'objectif est de configurer une instance VRF complète (`CLIENT_A`), d'activer MPLS LDP sur le lien backbone, de monter une session MP-BGP avec address-family VPNv4, et de placer une interface CE dans la VRF.
+
+### Objectif
+
+| Composant        | Rôle                                                        |
+|------------------|-------------------------------------------------------------|
+| VRF `CLIENT_A`   | Isolation du plan d'adressage client                        |
+| MPLS LDP         | Distribution des labels sur le lien backbone                |
+| MP-BGP VPNv4     | Transport des routes VPN entre PE (ou simulation mono-PE)   |
+| GigabitEthernet2 | Interface CE — adresse `192.168.1.1/24` dans la VRF         |
+
+### Topologie (simulation mono-device)
+
+```
+  CE1 ─────────────────────────────────── CE2
+        │                           │
+       PE1 ──── P (backbone) ──── PE2
+       Gi2      Gi1 (MPLS LDP)   (simulé)
+  VRF CLIENT_A  AS65000 BGP VPNv4
+```
+
+> Dans ce lab, PE1 est le seul équipement physique. CE1, P, et PE2 sont simulés
+> ou représentés par des loopbacks/neighbors statiques.
+
+### Paramètres de configuration
+
+| Paramètre              | Valeur             |
+|------------------------|--------------------|
+| VRF name               | `CLIENT_A`         |
+| Route Distinguisher    | `65000:1`          |
+| Route Target export    | `65000:1`          |
+| Route Target import    | `65000:1`          |
+| Interface backbone     | `GigabitEthernet1` |
+| Interface CE (VRF)     | `GigabitEthernet2` |
+| Adresse CE             | `192.168.1.1/24`   |
+| BGP AS                 | `65000`            |
+| BGP neighbor (PE2)     | `10.0.0.2`         |
+| Update-source          | `Loopback0`        |
+
+### Commandes de vérification
+
+```bash
+# Liste des VRFs et leurs RD
+show ip vrf
+
+# Session LDP avec le voisin backbone
+show mpls ldp neighbor
+
+# Table BGP VPNv4 (toutes les VRFs)
+show bgp vpnv4 unicast all
+
+# Table de forwarding MPLS (LFIB)
+show mpls forwarding-table
+```
+
+### Comment exécuter le script
+
+1. **Prérequis** : Python 3.10+, `netmiko` installé.
+
+   ```bash
+   pip install netmiko
+   ```
+
+2. **Renseigner les credentials** dans `mpls_l3vpn_lab.py` :
+
+   ```python
+   DEVICE = {
+       "device_type": "cisco_ios",
+       "host": "<HOST-HERE>",       # IP ou hostname du Cat8k
+       "username": "<USER-HERE>",   # compte SSH
+       "password": "<PASS-HERE>",   # mot de passe SSH
+   }
+   ```
+
+3. **Lancer le script** depuis la racine du lab :
+
+   ```bash
+   cd labs/devnet-mpls-l3vpn
+   python mpls_l3vpn_lab.py
+   ```
+
+4. **Consulter les résultats** dans `logs/mpls_l3vpn_output.txt`.
+
+---
+
+## EN — Description
+
+Single-device MPLS L3VPN simulation on a Cisco Catalyst 8000 (IOS-XE).  
+The lab configures a complete VRF instance (`CLIENT_A`), enables MPLS LDP on the backbone link, establishes an MP-BGP VPNv4 session, and places a CE-facing interface inside the VRF.
+
+### Objective
+
+| Component        | Role                                                        |
+|------------------|-------------------------------------------------------------|
+| VRF `CLIENT_A`   | Customer address-space isolation                            |
+| MPLS LDP         | Label distribution on the backbone link                     |
+| MP-BGP VPNv4     | VPN route transport between PEs (single-PE simulation)      |
+| GigabitEthernet2 | CE interface — address `192.168.1.1/24` inside the VRF      |
+
+### Topology (single-device simulation)
+
+```
+  CE1 ─────────────────────────────────── CE2
+        │                           │
+       PE1 ──── P (backbone) ──── PE2
+       Gi2      Gi1 (MPLS LDP)   (simulated)
+  VRF CLIENT_A  AS65000 BGP VPNv4
+```
+
+> In this lab, PE1 is the only physical device. CE1, P, and PE2 are simulated
+> or represented by loopbacks / static neighbors.
+
+### Configuration Parameters
+
+| Parameter              | Value              |
+|------------------------|--------------------|
+| VRF name               | `CLIENT_A`         |
+| Route Distinguisher    | `65000:1`          |
+| Route Target export    | `65000:1`          |
+| Route Target import    | `65000:1`          |
+| Backbone interface     | `GigabitEthernet1` |
+| CE interface (VRF)     | `GigabitEthernet2` |
+| CE address             | `192.168.1.1/24`   |
+| BGP AS                 | `65000`            |
+| BGP neighbor (PE2)     | `10.0.0.2`         |
+| Update-source          | `Loopback0`        |
+
+### Verification Commands
+
+```bash
+# List VRFs and their RDs
+show ip vrf
+
+# LDP session with backbone neighbor
+show mpls ldp neighbor
+
+# BGP VPNv4 table (all VRFs)
+show bgp vpnv4 unicast all
+
+# MPLS forwarding table (LFIB)
+show mpls forwarding-table
+```
+
+### How to Run the Script
+
+1. **Prerequisites**: Python 3.10+, `netmiko` installed.
+
+   ```bash
+   pip install netmiko
+   ```
+
+2. **Set credentials** in `mpls_l3vpn_lab.py`:
+
+   ```python
+   DEVICE = {
+       "device_type": "cisco_ios",
+       "host": "<HOST-HERE>",       # Cat8k IP or hostname
+       "username": "<USER-HERE>",   # SSH account
+       "password": "<PASS-HERE>",   # SSH password
+   }
+   ```
+
+3. **Run the script** from the lab directory:
+
+   ```bash
+   cd labs/devnet-mpls-l3vpn
+   python mpls_l3vpn_lab.py
+   ```
+
+4. **Check results** in `logs/mpls_l3vpn_output.txt`.

--- a/labs/devnet-mpls-l3vpn/mpls_l3vpn_lab.py
+++ b/labs/devnet-mpls-l3vpn/mpls_l3vpn_lab.py
@@ -1,0 +1,114 @@
+"""
+MPLS L3VPN lab — single-device simulation on Cisco Cat8k (IOS-XE).
+Configures VRF CLIENT_A, MPLS LDP, MP-BGP VPNv4, and a CE-facing interface,
+then captures verification output to logs/mpls_l3vpn_output.txt.
+"""
+
+import os
+from datetime import datetime
+from netmiko import ConnectHandler
+
+# ---------------------------------------------------------------------------
+# Device credentials — replace placeholders before running
+# ---------------------------------------------------------------------------
+DEVICE = {
+    "device_type": "cisco_ios",
+    "host": "<HOST-HERE>",
+    "username": "<USER-HERE>",
+    "password": "<PASS-HERE>",
+}
+
+LOG_FILE = os.path.join(os.path.dirname(__file__), "logs", "mpls_l3vpn_output.txt")
+
+# ---------------------------------------------------------------------------
+# Configuration payloads
+# ---------------------------------------------------------------------------
+VRF_CONFIG = [
+    "ip vrf CLIENT_A",
+    " rd 65000:1",
+    " route-target export 65000:1",
+    " route-target import 65000:1",
+    " exit",
+]
+
+MPLS_LDP_CONFIG = [
+    "mpls ip",
+    "interface GigabitEthernet1",
+    " mpls ip",
+    " exit",
+]
+
+MPBGP_CONFIG = [
+    "router bgp 65000",
+    " no bgp default ipv4-unicast",
+    " neighbor 10.0.0.2 remote-as 65000",
+    " neighbor 10.0.0.2 update-source Loopback0",
+    " address-family vpnv4",
+    "  neighbor 10.0.0.2 activate",
+    "  neighbor 10.0.0.2 send-community extended",
+    " exit-address-family",
+    " exit",
+]
+
+CE_INTERFACE_CONFIG = [
+    "interface GigabitEthernet2",
+    " ip vrf forwarding CLIENT_A",
+    " ip address 192.168.1.1 255.255.255.0",
+    " no shutdown",
+    " exit",
+]
+
+VERIFICATION_COMMANDS = [
+    "show ip vrf",
+    "show mpls ldp neighbor",
+    "show bgp vpnv4 unicast all",
+    "show mpls forwarding-table",
+]
+
+
+def push_config(connection, commands: list[str], section: str) -> str:
+    output = connection.send_config_set(commands)
+    print(f"[OK] {section} configured.")
+    return f"\n{'='*60}\n{section}\n{'='*60}\n{output}\n"
+
+
+def run_verifications(connection) -> str:
+    results = []
+    for cmd in VERIFICATION_COMMANDS:
+        output = connection.send_command(cmd)
+        results.append(f"\n{'='*60}\n$ {cmd}\n{'='*60}\n{output}\n")
+        print(f"[OK] {cmd}")
+    return "".join(results)
+
+
+def save_log(content: str) -> None:
+    os.makedirs(os.path.dirname(LOG_FILE), exist_ok=True)
+    with open(LOG_FILE, "w") as fh:
+        fh.write(content)
+    print(f"\n[LOG] Output saved to: {LOG_FILE}")
+
+
+def main() -> None:
+    print(f"\n[START] MPLS L3VPN lab — {datetime.now().strftime('%Y-%m-%d %H:%M:%S')}")
+    print(f"[INFO] Connecting to {DEVICE['host']} ...")
+
+    log = f"MPLS L3VPN Lab Output\nGenerated: {datetime.now()}\nDevice: {DEVICE['host']}\n"
+
+    with ConnectHandler(**DEVICE) as conn:
+        conn.enable()
+        print("[OK] Connected.\n")
+
+        log += push_config(conn, VRF_CONFIG, "VRF CLIENT_A (RD 65000:1 / RT 65000:1)")
+        log += push_config(conn, MPLS_LDP_CONFIG, "MPLS LDP — GigabitEthernet1")
+        log += push_config(conn, MPBGP_CONFIG, "MP-BGP AS65000 — VPNv4 address-family")
+        log += push_config(conn, CE_INTERFACE_CONFIG, "GigabitEthernet2 — VRF CLIENT_A 192.168.1.1/24")
+
+        print("\n[INFO] Running verification commands ...")
+        log += run_verifications(conn)
+
+    save_log(log)
+    print("[DONE] Lab complete.\n")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

- Adds `labs/devnet-mpls-l3vpn/mpls_l3vpn_lab.py`: Netmiko automation script that configures VRF `CLIENT_A` (RD/RT `65000:1`), MPLS LDP on `GigabitEthernet1`, MP-BGP AS65000 with VPNv4 address-family, and `GigabitEthernet2` as a CE-facing interface (`192.168.1.1/24` in VRF). Captures four verification commands and writes results to `logs/mpls_l3vpn_output.txt`.
- Adds `labs/devnet-mpls-l3vpn/README.md`: bilingual (FR/EN) documentation covering topology (CE1–PE1–P–PE2–CE2), configuration parameters table, verification commands, and step-by-step execution guide.
- Credentials use `<HOST-HERE>`, `<USER-HERE>`, `<PASS-HERE>` placeholders — no real values committed.

## Test plan

- [ ] Review `mpls_l3vpn_lab.py` — verify VRF, LDP, BGP, and interface config blocks
- [ ] Confirm all credential fields use placeholders only
- [ ] Review `README.md` — topology diagram, parameter table, FR/EN sections
- [ ] Run script against a DevNet sandbox Cat8k to validate end-to-end

https://claude.ai/code/session_01SNx35Srcvv7vbtJrb8frDM