### PR TITLE
fix: correct CV path and replace broken trophy widget

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 [![LinkedIn](https://img.shields.io/badge/LinkedIn-Profil-0077B5?style=flat-square&logo=linkedin)](https://www.linkedin.com/in/oumeziane69/)
 [![▶ Formation Pipeline](https://img.shields.io/badge/▶%20Formation-Pipeline%20CI%2FCD-red?logo=youtube)](https://youtu.be/vfQ1HxVoSHo)
 [![▶ Formation NotebookLM](https://img.shields.io/badge/▶%20Formation-NotebookLM%20v2-red?logo=youtube)](https://youtu.be/3CaPH8SWNH4)
-[![CV](https://img.shields.io/badge/CV-PDF-blue?logo=adobeacrobatreader)](https://github.com/oumeziane69-prog/network-portfolio/raw/principal/cv-hakim-oumeziane.pdf)
+[![CV](https://img.shields.io/badge/CV-PDF-blue?logo=adobeacrobatreader)](https://github.com/oumeziane69-prog/network-portfolio/raw/main/docs/cv-hakim-oumeziane.pdf)
 
 </div>
 
@@ -274,7 +274,8 @@ Pipeline CI/CD complet pour automatiser le déploiement de configurations résea
 | NETCONF/YANG | ncclient · Jinja2 | ✅ Complété |
 | pyATS/Genie | Cat8k · OSPF | ✅ Complété |
 
-[![Trophées](https://github-profile-trophy.vercel.app/?username=oumeziane69-prog&theme=darkhub&no-frame=true&row=1&column=6&margin-w=15)](https://github.com/ryo-ma/github-profile-trophy)
+[![GitHub followers](https://img.shields.io/github/followers/oumeziane69-prog?label=Followers&style=social)](https://github.com/oumeziane69-prog)
+[![GitHub stars](https://img.shields.io/github/stars/oumeziane69-prog?label=Stars&style=social)](https://github.com/oumeziane69-prog)
 
 ---
 


### PR DESCRIPTION
## Summary

- **CV badge URL**: Fixed incorrect path (`raw/principal/cv-hakim-oumeziane.pdf`) → correct path (`raw/main/docs/cv-hakim-oumeziane.pdf`) matching the actual file location in the repo
- **Trophy widget**: Replaced broken Vercel `github-profile-trophy` widget with two reliable static badges (GitHub Followers & GitHub Stars via `img.shields.io`)

## Test plan

- [ ] Verify CV badge links directly to the PDF file
- [ ] Verify Followers and Stars badges render and display correct counts

https://claude.ai/code/session_01N5UiiQECA4nuHtwCUrLRhL