### PR TITLE
fix: remove duplicate YouTube badge in Formation section

### DIFF
--- a/README.md
+++ b/README.md
@@ -246,8 +246,6 @@ Pipeline CI/CD complet pour automatiser le déploiement de configurations résea
 
 📄 [Voir la formation](docs/formation_netdevops.html)
 
-[![▶ Voir la vidéo](https://img.shields.io/badge/▶_Vidéo-YouTube-red)](https://youtu.be/vfQ1HxVoSHo)
-
 ---
 
 ## 📊 GitHub Stats


### PR DESCRIPTION
## Summary

- Removes the standalone `▶ Voir la vidéo` YouTube badge from the Formation NetDevOps section
- This badge duplicated the `▶ Formation Pipeline CI/CD` badge already present in the header row, both linking to the same video (https://youtu.be/vfQ1HxVoSHo)

## Test plan

- [ ] Verify the Formation NetDevOps section no longer contains a YouTube badge
- [ ] Verify the two YouTube badges in the header row are unaffected

https://claude.ai/code/session_01N5UiiQECA4nuHtwCUrLRhL