### PR TITLE
docs: add both YouTube badges in Formation section

### DIFF
--- a/README.md
+++ b/README.md
@@ -246,6 +246,8 @@ Pipeline CI/CD complet pour automatiser le déploiement de configurations résea
 
 📄 [Voir la formation](docs/formation_netdevops.html)
 
+[![▶ Pipeline CI/CD](https://img.shields.io/badge/▶%20Vidéo-Pipeline%20CI%2FCD-red?logo=youtube)](https://youtu.be/vfQ1HxVoSHo) [![▶ NotebookLM v2](https://img.shields.io/badge/▶%20Vidéo-NotebookLM%20v2-red?logo=youtube)](https://youtu.be/3CaPH8SWNH4)
+
 ---
 
 ## 📊 GitHub Stats


### PR DESCRIPTION
## Summary

- Adds two YouTube video badges inline under the Formation NetDevOps link:
  - `▶ Pipeline CI/CD` → https://youtu.be/vfQ1HxVoSHo
  - `▶ NotebookLM v2` → https://youtu.be/3CaPH8SWNH4

## Test plan

- [ ] Verify both badges appear on the same line below the formation document link
- [ ] Verify each badge links to the correct YouTube video

https://claude.ai/code/session_01N5UiiQECA4nuHtwCUrLRhL