### PR TITLE
feat(ci): add enable-branch-protection workflow

### DIFF
--- a/.github/workflows/enable-branch-protection.yml
+++ b/.github/workflows/enable-branch-protection.yml
@@ -1,0 +1,66 @@
+name: Enable Branch Protection on main
+
+on:
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+permissions:
+  administration: write
+
+jobs:
+  protect-main:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Enable branch protection on main
+        env:
+          GH_TOKEN: ${{ secrets.ADMIN_TOKEN }}
+        run: |
+          HTTP_STATUS=$(curl -s -o /tmp/bp_response.json -w "%{http_code}" \
+            -X PUT \
+            -H "Authorization: Bearer $GH_TOKEN" \
+            -H "Accept: application/vnd.github+json" \
+            -H "X-GitHub-Api-Version: 2022-11-28" \
+            https://api.github.com/repos/${{ github.repository }}/branches/main/protection \
+            -d '{
+              "required_status_checks": null,
+              "enforce_admins": false,
+              "required_pull_request_reviews": {
+                "required_approving_review_count": 1,
+                "dismiss_stale_reviews": false,
+                "require_code_owner_reviews": false
+              },
+              "restrictions": null,
+              "allow_force_pushes": false,
+              "allow_deletions": false
+            }')
+          echo "HTTP status: $HTTP_STATUS"
+          cat /tmp/bp_response.json
+          if [ "$HTTP_STATUS" = "200" ]; then
+            echo "Branch protection enabled successfully on main."
+          else
+            echo "Failed to enable branch protection (HTTP $HTTP_STATUS)."
+            exit 1
+          fi
+
+      - name: Confirm branch protection status
+        env:
+          GH_TOKEN: ${{ secrets.ADMIN_TOKEN }}
+        run: |
+          curl -s \
+            -H "Authorization: Bearer $GH_TOKEN" \
+            -H "Accept: application/vnd.github+json" \
+            -H "X-GitHub-Api-Version: 2022-11-28" \
+            https://api.github.com/repos/${{ github.repository }}/branches/main/protection \
+            | python3 -c "
+import json, sys
+d = json.load(sys.stdin)
+print('=== Branch Protection Summary ===')
+print('Required PR reviews:', d.get('required_pull_request_reviews', {}).get('required_approving_review_count', 'N/A'))
+rsc = d.get('required_status_checks')
+print('Required status checks strict:', rsc.get('strict') if rsc else 'N/A')
+print('Allow force pushes:', d.get('allow_force_pushes', {}).get('enabled', 'N/A'))
+print('Allow deletions:', d.get('allow_deletions', {}).get('enabled', 'N/A'))
+print('Enforce admins:', d.get('enforce_admins', {}).get('enabled', 'N/A'))
+print('=== Protection ACTIVE ===')
+"


### PR DESCRIPTION
## Summary

Creates `.github/workflows/enable-branch-protection.yml`, absent from this repo.

- Modeled after the `scc-coordinator` reference implementation
- **Token** : `ADMIN_TOKEN` (required for branch protection API)
- **Trigger** : `push: branches: [main]` + `workflow_dispatch`
- **Permission** : `administration: write`
- Enforces: 1 PR review required, no force pushes, no deletions
- Confirms protection with a read-back step after applying

## Context

Identified as missing during post-HNO-merge audit on 2026-04-22. The other 3 repos all have this workflow; network-portfolio was the only one without it.