### PR TITLE
fix(hno): fix multiline body in gh issue comment

### DIFF
--- a/.github/workflows/hno-nightly-check.yml
+++ b/.github/workflows/hno-nightly-check.yml
@@ -175,10 +175,8 @@ jobs:
               --search "$DATE in:title" \
               --json number --jq '.[0].number' 2>/dev/null || true)
             if [ -n "$EXISTING" ] && [ "$EXISTING" != "null" ]; then
-              gh issue comment "$EXISTING" \
-                --body "**Re-run $(date --iso-8601=seconds) :**
-
-$(cat /tmp/issue_body.txt)"
+              RERUN_BODY="**Re-run $(date --iso-8601=seconds) :**"$'\n'"$(cat /tmp/issue_body.txt)"
+              gh issue comment "$EXISTING" --body "$RERUN_BODY"
             else
               gh issue create \
                 --title "$TITLE" \


### PR DESCRIPTION
## Summary

- Replaces the heredoc-style `--body` in `gh issue comment` with an explicit variable using `$'\n'` for safe newline handling
- Prevents YAML parsing issues caused by unquoted multiline strings inside a `run:` block

## Change

```diff
-              gh issue comment "$EXISTING" \
-                --body "**Re-run $(date --iso-8601=seconds) :**
-$(cat /tmp/issue_body.txt)"
+              RERUN_BODY="**Re-run $(date --iso-8601=seconds) :**"$'\n'"$(cat /tmp/issue_body.txt)"
+              gh issue comment "$EXISTING" --body "$RERUN_BODY"
```

## Test plan
- [ ] Trigger workflow manually via `workflow_dispatch`
- [ ] Verify an existing open HNO issue receives a comment with correct formatting