### PR TITLE
fix: yamllint line-length, broken streak badge (closes #58 #65)

### DIFF
--- a/.github/workflows/hno-nightly-check.yml
+++ b/.github/workflows/hno-nightly-check.yml
@@ -160,9 +160,11 @@ jobs:
           git add -A
           git commit -m "fix(hno): auto-fix trailing whitespace [$DATE]"
           git push -u origin "$BRANCH"
+          PR_BODY="Automated fix from HNO nightly check:"
+          PR_BODY="${PR_BODY} trailing whitespace removed from modified YAML/Python files."
           PR_URL=$(gh pr create \
             --title "fix(hno): auto-fix trailing whitespace [$DATE]" \
-            --body "Automated fix from HNO nightly check: trailing whitespace removed from modified YAML/Python files." \
+            --body "$PR_BODY" \
             --base main \
             --head "$BRANCH" \
             --label "auto-fix" 2>&1 | tail -1)

--- a/.github/workflows/hno-weekly-report.yml
+++ b/.github/workflows/hno-weekly-report.yml
@@ -48,9 +48,10 @@ jobs:
             } >> "$REPORT_FILE"
 
             # --- Nightly runs ---
+            NIGHTLY_URL="https://api.github.com/repos/${OWNER}/${REPO}"
+            NIGHTLY_URL="${NIGHTLY_URL}/actions/workflows/hno-nightly-check.yml/runs?per_page=100"
             RUNS_JSON=$(curl -sf -H "Authorization: Bearer ${GH_TOKEN}" \
-              "https://api.github.com/repos/${OWNER}/${REPO}/actions/workflows/hno-nightly-check.yml/runs?per_page=100" \
-              || echo '{"workflow_runs":[]}')
+              "$NIGHTLY_URL" || echo '{"workflow_runs":[]}')
 
             RUN_OK=0
             RUN_FAIL=0
@@ -66,6 +67,9 @@ jobs:
             if [ "$RUN_COUNT" -eq 0 ]; then
               echo "  - ⚠️ Aucun run trouvé pour cette période" >> "$REPORT_FILE"
             else
+              JQ_RUNS='.workflow_runs[] | select(.created_at >= $since'
+              JQ_RUNS="${JQ_RUNS} and .conclusion != null)"
+              JQ_RUNS="${JQ_RUNS} | [.conclusion, .created_at, (.id | tostring)] | @tsv"
               while IFS=$'\t' read -r CONCLUSION RUN_DATE RUN_ID; do
                 [ -z "$CONCLUSION" ] && continue
 
@@ -83,9 +87,10 @@ jobs:
                   ICON="❌"
                 fi
 
-                echo "  - ${ICON} ${SHORT_DATE} — statut: \`${CONCLUSION}\`, erreurs détectées: ${ERRORS}" >> "$REPORT_FILE"
-              done < <(echo "$RUNS_JSON" | jq -r --arg since "$WEEK_START" \
-                '.workflow_runs[] | select(.created_at >= $since and .conclusion != null) | [.conclusion, .created_at, (.id | tostring)] | @tsv')
+                MSG="  - ${ICON} ${SHORT_DATE} — statut: \`${CONCLUSION}\`,"
+                MSG="${MSG} erreurs détectées: ${ERRORS}"
+                echo "${MSG}" >> "$REPORT_FILE"
+              done < <(echo "$RUNS_JSON" | jq -r --arg since "$WEEK_START" "$JQ_RUNS")
             fi
 
             REPO_TOTAL=$((RUN_OK + RUN_FAIL))
@@ -135,8 +140,11 @@ jobs:
               echo ""
             } >> "$REPORT_FILE"
 
-            PR_LINES=$(echo "$PRS_JSON" | jq -r --arg since "$WEEK_START" \
-              '.[] | select(.merged_at != null and .merged_at >= $since and (.head.ref | startswith("claude/hno-fix-"))) | "  - #\(.number) \(.title) — mergée le \(.merged_at | split(\"T\")[0])"')
+            JQ_PR='.[] | select(.merged_at != null and .merged_at >= $since'
+            JQ_PR="${JQ_PR} and (.head.ref | startswith(\"claude/hno-fix-\")))"
+            JQ_PR="${JQ_PR} | \"  - #\(.number) \(.title) — mergée le"
+            JQ_PR="${JQ_PR} \(.merged_at | split(\"T\")[0])\""
+            PR_LINES=$(echo "$PRS_JSON" | jq -r --arg since "$WEEK_START" "$JQ_PR")
 
             if [ -n "$PR_LINES" ]; then
               echo "$PR_LINES" >> "$REPORT_FILE"

--- a/README.md
+++ b/README.md
@@ -253,7 +253,7 @@ NSE4 ──► NSE7 ──► MPLS/L3VPN ──► SNS-100
 
 ![Top Languages](https://github-readme-stats.vercel.app/api/top-langs/?username=oumeziane69-prog&layout=compact&theme=dark&hide_border=true)
 
-![GitHub Streak](https://streak-stats.demolab.com/?user=oumeziane69-prog&theme=dark&hide_border=true)
+![GitHub Streak](https://github-readme-streak-stats.herokuapp.com/?user=oumeziane69-prog&theme=dark&hide_border=true)
 
 </div>
 


### PR DESCRIPTION
## Summary

- **hno-nightly-check.yml**: extract PR `--body` string into a `PR_BODY` variable — line was 121 chars
- **hno-weekly-report.yml**: three wraps:
  - Nightly API URL extracted to `NIGHTLY_URL` variable (line 52, 121 chars)
  - `echo` with em-dash + accented chars split into `MSG` variable (line 86, 128 chars)
  - Both jq filters (`JQ_RUNS`, `JQ_PR`) extracted before their loops (lines 88+139, 145+199 chars)
- **README.md**: replace broken `streak-stats.demolab.com` badge with `github-readme-streak-stats.herokuapp.com`
- **Note**: `enable-branch-protection.yml` referenced in #58 no longer exists in the repo — no action needed

Closes #58, #65

## Test plan

- [ ] `awk 'length > 120' hno-nightly-check.yml hno-weekly-report.yml` returns no output
- [ ] All jq filters produce the same output as before (logic unchanged, only variable extraction)
- [ ] GitHub Streak badge renders correctly in README

https://claude.ai/code/session_012zbYdmPC5ktFnAsY8Lhssw

---
_Generated by [Claude Code](https://claude.ai/code/session_012zbYdmPC5ktFnAsY8Lhssw)_