### PR TITLE
docs(CLAUDE.md): add Session Log section

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -65,3 +65,14 @@ Rules:
 Use placeholders in examples: `<IP-HERE>`, `<PASSWORD-HERE>`, `<TOKEN-HERE>`
 
 Real values must come from `.env` files that are listed in `.gitignore` and never committed.
+
+---
+## Session Log
+
+After every Claude Code session, append a summary here:
+
+Format:
+### YYYY-MM-DD — <branch-name>
+- Files modified: <list>
+- Actions: <summary>
+- Status: ✅ Done / 🔄 In progress / ⚠️ Issue


### PR DESCRIPTION
## Summary

- Appends a `## Session Log` section at the end of `CLAUDE.md`
- Defines a standard format for tracking Claude Code sessions (date, branch, files modified, actions, status)
- Section was not previously present in this file

## Test plan

- [ ] Verify `CLAUDE.md` renders correctly on GitHub
- [ ] Confirm the Session Log section appears at the end of the file
- [ ] Confirm existing content is unchanged

---
_Generated by [Claude Code](https://claude.ai/code/session_01BP5tttB3RS4XjoP4jZvKuA)_