### PR TITLE
fix(readme): replace Roadmap badge URL with placeholder

### DIFF
--- a/README.md
+++ b/README.md
@@ -280,7 +280,7 @@ NSE4 ──► NSE7 ──► MPLS/L3VPN ──► SNS-100
 
 **EN** — Progress tracking for NetDevOps labs, certifications, and projects. Full board available on GitHub Project.
 
-[![GitHub Project — Network Portfolio Roadmap](https://img.shields.io/badge/GitHub_Project-Network_Portfolio_Roadmap-0075ca?style=flat-square&logo=github)](https://github.com/users/oumeziane69-prog/projects)
+[![GitHub Project — Network Portfolio Roadmap](https://img.shields.io/badge/GitHub_Project-Network_Portfolio_Roadmap-0075ca?style=flat-square&logo=github)](<PROJECT-URL-HERE>)
 
 | Item | Type | Tech | Priority | Status |
 |------|------|------|----------|--------|


### PR DESCRIPTION
## Summary

- Replaces `https://github.com/users/oumeziane69-prog/projects` in the Roadmap badge with `<PROJECT-URL-HERE>`
- Makes the placeholder explicit so it's easy to find and update once the GitHub Project board is created

## Test plan
- [ ] After creating the GitHub Project board, replace `<PROJECT-URL-HERE>` in README.md with the actual project URL (e.g. `https://github.com/users/oumeziane69-prog/projects/N`)

https://claude.ai/code/session_01AiQjo8LVGRSQB3eruLanBq

---
_Generated by [Claude Code](https://claude.ai/code/session_01AiQjo8LVGRSQB3eruLanBq)_