### PR TITLE
fix: replace roadmap badge placeholder URL with real GitHub Project link

### DIFF
--- a/README.md
+++ b/README.md
@@ -280,7 +280,7 @@ NSE4 ──► NSE7 ──► MPLS/L3VPN ──► SNS-100
 
 **EN** — Progress tracking for NetDevOps labs, certifications, and projects. Full board available on GitHub Project.
 
-[![GitHub Project — Network Portfolio Roadmap](https://img.shields.io/badge/GitHub_Project-Network_Portfolio_Roadmap-0075ca?style=flat-square&logo=github)](<PROJECT-URL-HERE>)
+[![GitHub Project — Network Portfolio Roadmap](https://img.shields.io/badge/GitHub_Project-Network_Portfolio_Roadmap-0075ca?style=flat-square&logo=github)](https://github.com/users/oumeziane69-prog/projects/1)
 
 | Item | Type | Tech | Priority | Status |
 |------|------|------|----------|--------|


### PR DESCRIPTION
## Summary
- Replaced `<PROJECT-URL-HERE>` placeholder on README.md line 283 with the real GitHub Project URL: `https://github.com/users/oumeziane69-prog/projects/1`
- The roadmap badge now links correctly to the Network Portfolio GitHub Project board

## Test plan
- [ ] Click the "GitHub Project — Network Portfolio Roadmap" badge in the README and verify it navigates to the correct project board

https://claude.ai/code/session_01LBCtqYFg4A1ygZf6q9b2f9

---
_Generated by [Claude Code](https://claude.ai/code/session_01LBCtqYFg4A1ygZf6q9b2f9)_