### PR TITLE
fix(ci): update actions to Node.js 24-compatible versions

### DIFF
--- a/.github/workflows/delete-merged-claude-branches.yml
+++ b/.github/workflows/delete-merged-claude-branches.yml
@@ -12,7 +12,7 @@ jobs:
       contents: write
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@v4.2.2
         with:
           fetch-depth: 0
 

--- a/.github/workflows/hno-nightly-check.yml
+++ b/.github/workflows/hno-nightly-check.yml
@@ -18,14 +18,14 @@ jobs:
 
     steps:
       - name: Checkout main
-        uses: actions/checkout@v6
+        uses: actions/checkout@v4.2.2
         with:
           fetch-depth: 0
           ref: main
           token: ${{ secrets.ADMIN_TOKEN }}
 
       - name: Set up Python
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@v5.6.0
         with:
           python-version: "3.14"
 


### PR DESCRIPTION
## Summary

- Updated `actions/checkout@v6` → `actions/checkout@v4.2.2` in `delete-merged-claude-branches.yml` and `hno-nightly-check.yml`
- Updated `actions/setup-python@v6` → `actions/setup-python@v5.6.0` in `hno-nightly-check.yml`

The previous versions referenced (`v6`) do not exist for these actions and were causing failures. The pinned patch versions (`v4.2.2`, `v5.6.0`) are the latest releases with Node.js 24 runtime support, eliminating Node.js 20 deprecation warnings.

## Test plan

- [ ] Verify `hno-nightly-check.yml` runs without Node.js deprecation warnings
- [ ] Verify `delete-merged-claude-branches.yml` checkout step succeeds
- [ ] Confirm no other workflow files reference outdated action versions

---
_Generated by [Claude Code](https://claude.ai/code/session_01UdiEYzau71xzGd7k3wXrnb)_