### PR TITLE
fix(renovate): block major upgrades for github-actions

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -21,6 +21,11 @@
       "matchPackageNames": ["node"],
       "allowedVersions": "24.x",
       "labels": ["node-upgrade"]
+    },
+    {
+      "matchManagers": ["github-actions"],
+      "matchUpdateTypes": ["major"],
+      "enabled": false
     }
   ],
   "labels": ["renovate", "dependencies"],


### PR DESCRIPTION
Adds a packageRule to disable major version upgrades for GitHub Actions via Renovate. Closes related major-upgrade Renovate PRs.

---
_Generated by [Claude Code](https://claude.ai/code/session_01VB9LXiUje2RFZEb396V6xs)_