### PR TITLE
fix: add Formation HTML badge, mark transmission lab complete

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@
 [![▶ YouTube](https://img.shields.io/badge/▶_Formation-YouTube-red?logo=youtube)](https://youtu.be/vfQ1HxVoSHo)
 [![CV](https://img.shields.io/badge/CV-PDF-blue?style=flat-square&logo=adobeacrobatreader)](https://raw.githubusercontent.com/oumeziane69-prog/network-portfolio/main/docs/cv-hakim-oumeziane.pdf)
 [![Discussions](https://img.shields.io/badge/Discussions-purple?style=flat-square&logo=github)](https://github.com/oumeziane69-prog/network-portfolio/discussions)
+[![▶ Formation HTML](https://img.shields.io/badge/▶_Formation-HTML-orange?style=flat-square)](docs/formation_netdevops.html)
 
 </div>
 

--- a/labs/transmission/README.md
+++ b/labs/transmission/README.md
@@ -30,7 +30,7 @@ Les CNPE EDF disposent de plusieurs types de liaisons de transmission :
 
 ## Statut / Status
 
-🚧 En cours de construction
+✅ Complété
 
 ---
 


### PR DESCRIPTION
## Summary

- **Formation HTML badge**: add `▶ Formation HTML` badge (orange, `style=flat-square`) to the README header, linking to `docs/formation_netdevops.html` via local path
- **Transmission lab status**: update `labs/transmission/README.md` from `🚧 En cours de construction` → `✅ Complété`
- **Note**: the `transmission` row in the Labs actifs table (README.md) was already `✅ Complété` since PR #94 — no change needed there

## Test plan

- [ ] Formation HTML badge renders in orange and links correctly to `docs/formation_netdevops.html`
- [ ] `labs/transmission/README.md` Statut section shows `✅ Complété`

https://claude.ai/code/session_01PvfJwUeZUBRvPXzpRbSD7y

---
_Generated by [Claude Code](https://claude.ai/code/session_01PvfJwUeZUBRvPXzpRbSD7y)_