### PR TITLE
lab devnet-netconf: NETCONF/YANG lab 010 — Cat8k IOS-XE 17.9

### DIFF
--- a/labs/devnet-netconf/README.md
+++ b/labs/devnet-netconf/README.md
@@ -1,22 +1,58 @@
-# Lab NETCONF — Cisco C8000V IOS XE / NETCONF Lab — Cisco C8000V IOS XE
+# Lab 010 — NETCONF/YANG — Cisco Cat8k IOS-XE / NETCONF/YANG Lab — Cisco Cat8k IOS-XE
+
+**Status: Completed ✅**
 
 ---
 
 ## FR — Description
 
-Ce lab démontre l'automatisation réseau via **NETCONF/YANG** sur un routeur virtuel Cisco C8000V.
+Ce lab démontre l'automatisation réseau via **NETCONF/YANG** sur un routeur Cisco Catalyst 8000V.
+Deux scripts Python couvrent : la récupération de la configuration complète et un get filtré
+retournant hostname + interfaces spécifiques au format JSON.
 
 | Paramètre | Valeur |
 |---|---|
-| Plateforme | Cisco C8000V IOS XE 17.15.04c |
+| Plateforme | Cisco Cat8k IOS-XE 17.9 |
 | Protocole | NETCONF (SSH port 830) |
 | Bibliothèque Python | ncclient 0.7.1 |
-| Modèles YANG | `ietf-interfaces`, `Cisco-IOS-XE-native` |
+| Version Python | 3.8 |
+| Modèle YANG | `Cisco-IOS-XE-native` |
 
-### Opérations démontrées
+### Activation de NETCONF sur IOS-XE
 
-- **get interfaces** — récupère l'état opérationnel de toutes les interfaces via `ietf-interfaces`
-- **get-config OSPF** — extrait la configuration OSPF en XML via `Cisco-IOS-XE-native`
+```
+R1# conf t
+R1(config)# netconf-yang
+R1(config)# end
+R1# show netconf-yang status
+```
+
+### Scripts
+
+| Script | Opération | Sortie |
+|---|---|---|
+| `netconf_get.py` | `get-config` sans filtre | XML — configuration complète |
+| `netconf_interfaces.py` | `get-config` filtré (subtree) | JSON — hostname + interfaces ciblées |
+
+### Interfaces récupérées par le filtre
+
+- `GigabitEthernet1`
+- `Vlan20`, `Vlan21`
+- `VirtualPortGroup31`
+
+### Point clé — syntaxe ncclient
+
+La syntaxe `filter=("subtree", to_ele(...))` est **obligatoire** pour passer un filtre XML
+sous forme d'objet ElementTree à ncclient :
+
+```python
+from ncclient.xml_ import to_ele
+
+response = conn.get_config(
+    source="running",
+    filter=("subtree", to_ele(FILTER_XML)),
+)
+```
 
 ### Prérequis
 
@@ -36,25 +72,60 @@ export DEVNET_PASS=<PASSWORD-HERE>
 
 ```bash
 python netconf_get.py
+python netconf_interfaces.py
 ```
 
 ---
 
 ## EN — Description
 
-This lab demonstrates network automation via **NETCONF/YANG** on a Cisco C8000V virtual router.
+This lab demonstrates network automation via **NETCONF/YANG** on a Cisco Catalyst 8000V router.
+Two Python scripts cover: full running-config retrieval and a filtered get returning hostname
+and specific interfaces as JSON.
 
 | Parameter | Value |
 |---|---|
-| Platform | Cisco C8000V IOS XE 17.15.04c |
+| Platform | Cisco Cat8k IOS-XE 17.9 |
 | Protocol | NETCONF (SSH port 830) |
 | Python library | ncclient 0.7.1 |
-| YANG models | `ietf-interfaces`, `Cisco-IOS-XE-native` |
+| Python version | 3.8 |
+| YANG model | `Cisco-IOS-XE-native` |
 
-### Demonstrated operations
+### Enabling NETCONF on IOS-XE
 
-- **get interfaces** — retrieves the operational state of all interfaces via `ietf-interfaces`
-- **get-config OSPF** — extracts OSPF configuration as XML via `Cisco-IOS-XE-native`
+```
+R1# conf t
+R1(config)# netconf-yang
+R1(config)# end
+R1# show netconf-yang status
+```
+
+### Scripts
+
+| Script | Operation | Output |
+|---|---|---|
+| `netconf_get.py` | `get-config` with no filter | XML — full running config |
+| `netconf_interfaces.py` | `get-config` filtered (subtree) | JSON — hostname + targeted interfaces |
+
+### Interfaces returned by the filter
+
+- `GigabitEthernet1`
+- `Vlan20`, `Vlan21`
+- `VirtualPortGroup31`
+
+### Key point — ncclient syntax
+
+The `filter=("subtree", to_ele(...))` syntax is **required** to pass an XML filter
+as an ElementTree object to ncclient:
+
+```python
+from ncclient.xml_ import to_ele
+
+response = conn.get_config(
+    source="running",
+    filter=("subtree", to_ele(FILTER_XML)),
+)
+```
 
 ### Prerequisites
 
@@ -74,45 +145,57 @@ export DEVNET_PASS=<PASSWORD-HERE>
 
 ```bash
 python netconf_get.py
+python netconf_interfaces.py
 ```
 
 ---
 
 ## Output example / Exemple de sortie
 
-```xml
-=== GET interfaces (ietf-interfaces) ===
-<?xml version="1.0" encoding="UTF-8"?>
-<rpc-reply xmlns="urn:ietf:params:xml:ns:netconf:base:1.0">
-  <data>
-    <interfaces xmlns="urn:ietf:params:xml:ns:yang:ietf-interfaces">
-      <interface>
-        <name>GigabitEthernet1</name>
-        <type xmlns:ianaift="urn:ietf:params:xml:ns:yang:iana-if-type">
-          ianaift:ethernetCsmacd
-        </type>
-        <enabled>true</enabled>
-      </interface>
-    </interfaces>
-  </data>
-</rpc-reply>
+### netconf_get.py
 
-=== GET-CONFIG OSPF (Cisco-IOS-XE-native) ===
-<?xml version="1.0" encoding="UTF-8"?>
-<rpc-reply xmlns="urn:ietf:params:xml:ns:netconf:base:1.0">
+```
+=== GET full running config (no filter) ===
+<?xml version="1.0" ?>
+<rpc-reply xmlns="urn:ietf:params:xml:ns:netconf:base:1.0" message-id="urn:uuid:...">
   <data>
     <native xmlns="http://cisco.com/ns/yang/Cisco-IOS-XE-native">
-      <router>
-        <ospf xmlns="http://cisco.com/ns/yang/Cisco-IOS-XE-ospf">
-          <id>1</id>
-          <network>
-            <ip><NETWORK-HERE></ip>
-            <mask><MASK-HERE></mask>
-            <area><AREA-HERE></area>
-          </network>
-        </ospf>
-      </router>
+      <hostname>Cat8k-Lab</hostname>
+      <version>17.9</version>
+      <interface>
+        ...
+      </interface>
     </native>
   </data>
 </rpc-reply>
+```
+
+### netconf_interfaces.py
+
+```json
+{
+  "hostname": "Cat8k-Lab",
+  "interfaces": {
+    "GigabitEthernet1": {
+      "name": "1",
+      "ip_address": "<IP-HERE>",
+      "description": "MGMT",
+      "shutdown": false
+    },
+    "Vlan20": {
+      "name": "20",
+      "ip_address": "<IP-HERE>",
+      "shutdown": false
+    },
+    "Vlan21": {
+      "name": "21",
+      "shutdown": false
+    },
+    "VirtualPortGroup31": {
+      "name": "31",
+      "ip_address": "<IP-HERE>",
+      "shutdown": false
+    }
+  }
+}
 ```

--- a/labs/devnet-netconf/netconf_get.py
+++ b/labs/devnet-netconf/netconf_get.py
@@ -1,6 +1,6 @@
 """
-NETCONF lab — Cisco C8000V IOS XE 17.15.04c
-Demonstrates: get interfaces (ietf-interfaces) + get-config OSPF (Cisco-IOS-XE-native)
+netconf_get.py — Full running config via NETCONF
+Platform: Cisco Cat8k IOS-XE 17.9 | ncclient 0.7.1 | Python 3.8
 Credentials via env vars: DEVNET_HOST, DEVNET_USER, DEVNET_PASS
 """
 
@@ -12,37 +12,32 @@ from ncclient import manager
 
 NETCONF_PORT = 830
 
-FILTER_INTERFACES = """
-<filter>
-  <interfaces xmlns="urn:ietf:params:xml:ns:yang:ietf-interfaces"/>
-</filter>
-"""
 
-FILTER_OSPF = """
-<filter>
-  <native xmlns="http://cisco.com/ns/yang/Cisco-IOS-XE-native">
-    <router>
-      <ospf xmlns="http://cisco.com/ns/yang/Cisco-IOS-XE-ospf"/>
-    </router>
-  </native>
-</filter>
-"""
-
-
-def pretty(xml_str: str) -> str:
+def pretty(xml_str):
     try:
         return parseString(xml_str).toprettyxml(indent="  ")
     except Exception:
         return xml_str
 
 
-def get_credentials() -> tuple[str, str, str]:
+def get_credentials():
     host = os.environ.get("DEVNET_HOST")
     user = os.environ.get("DEVNET_USER")
     password = os.environ.get("DEVNET_PASS")
-    missing = [name for name, val in [("DEVNET_HOST", host), ("DEVNET_USER", user), ("DEVNET_PASS", password)] if not val]
+    missing = [
+        name
+        for name, val in [
+            ("DEVNET_HOST", host),
+            ("DEVNET_USER", user),
+            ("DEVNET_PASS", password),
+        ]
+        if not val
+    ]
     if missing:
-        print(f"Error: missing environment variable(s): {', '.join(missing)}", file=sys.stderr)
+        print(
+            f"Error: missing environment variable(s): {', '.join(missing)}",
+            file=sys.stderr,
+        )
         sys.exit(1)
     return host, user, password
 
@@ -60,12 +55,8 @@ def main():
         look_for_keys=False,
         allow_agent=False,
     ) as conn:
-        print("=== GET interfaces (ietf-interfaces) ===")
-        response = conn.get(FILTER_INTERFACES)
-        print(pretty(str(response)))
-
-        print("=== GET-CONFIG OSPF (Cisco-IOS-XE-native) ===")
-        response = conn.get_config(source="running", filter=FILTER_OSPF)
+        print("=== GET full running config (no filter) ===")
+        response = conn.get_config(source="running")
         print(pretty(str(response)))
 
 

--- a/labs/devnet-netconf/netconf_interfaces.py
+++ b/labs/devnet-netconf/netconf_interfaces.py
@@ -1,0 +1,142 @@
+"""
+netconf_interfaces.py — Filtered NETCONF get via Cisco-IOS-XE-native YANG model
+Platform: Cisco Cat8k IOS-XE 17.9 | ncclient 0.7.1 | Python 3.8
+Returns: hostname, GigabitEthernet1, Vlan20/21, VirtualPortGroup31 as JSON
+Credentials via env vars: DEVNET_HOST, DEVNET_USER, DEVNET_PASS
+"""
+
+import json
+import os
+import sys
+from xml.etree import ElementTree as ET
+
+from ncclient import manager
+from ncclient.xml_ import to_ele
+
+NETCONF_PORT = 830
+
+# Subtree filter — hostname + targeted interfaces (Cisco-IOS-XE-native)
+FILTER_XML = """
+<filter>
+  <native xmlns="http://cisco.com/ns/yang/Cisco-IOS-XE-native">
+    <hostname/>
+    <interface>
+      <GigabitEthernet>
+        <name>1</name>
+      </GigabitEthernet>
+      <Vlan>
+        <name>20</name>
+      </Vlan>
+      <Vlan>
+        <name>21</name>
+      </Vlan>
+      <VirtualPortGroup>
+        <name>31</name>
+      </VirtualPortGroup>
+    </interface>
+  </native>
+</filter>
+"""
+
+NS = {
+    "nc": "urn:ietf:params:xml:ns:netconf:base:1.0",
+    "ios": "http://cisco.com/ns/yang/Cisco-IOS-XE-native",
+}
+
+
+def get_credentials():
+    host = os.environ.get("DEVNET_HOST")
+    user = os.environ.get("DEVNET_USER")
+    password = os.environ.get("DEVNET_PASS")
+    missing = [
+        name
+        for name, val in [
+            ("DEVNET_HOST", host),
+            ("DEVNET_USER", user),
+            ("DEVNET_PASS", password),
+        ]
+        if not val
+    ]
+    if missing:
+        print(
+            f"Error: missing environment variable(s): {', '.join(missing)}",
+            file=sys.stderr,
+        )
+        sys.exit(1)
+    return host, user, password
+
+
+def _text(element, xpath):
+    node = element.find(xpath, NS)
+    return node.text if node is not None else None
+
+
+def parse_response(response_xml):
+    root = ET.fromstring(response_xml)
+    native = root.find(".//ios:native", NS)
+    if native is None:
+        return {"error": "native element not found in response"}
+
+    result = {}
+
+    hostname = _text(native, "ios:hostname")
+    if hostname:
+        result["hostname"] = hostname
+
+    interfaces = {}
+    iface_container = native.find("ios:interface", NS)
+    if iface_container is not None:
+        type_map = [
+            ("ios:GigabitEthernet", "GigabitEthernet"),
+            ("ios:Vlan", "Vlan"),
+            ("ios:VirtualPortGroup", "VirtualPortGroup"),
+        ]
+        for xpath, label in type_map:
+            for iface in iface_container.findall(xpath, NS):
+                name_el = iface.find("ios:name", NS)
+                if name_el is None:
+                    continue
+                key = f"{label}{name_el.text}"
+                entry = {"name": name_el.text}
+
+                ip_addr = _text(iface, ".//ios:address/ios:primary/ios:address")
+                if ip_addr:
+                    entry["ip_address"] = ip_addr
+
+                desc = _text(iface, "ios:description")
+                if desc:
+                    entry["description"] = desc
+
+                # shutdown leaf is present (no value) when interface is shut
+                entry["shutdown"] = iface.find("ios:shutdown", NS) is not None
+
+                interfaces[key] = entry
+
+    result["interfaces"] = interfaces
+    return result
+
+
+def main():
+    host, user, password = get_credentials()
+
+    with manager.connect(
+        host=host,
+        port=NETCONF_PORT,
+        username=user,
+        password=password,
+        hostkey_verify=False,
+        device_params={"name": "iosxe"},
+        look_for_keys=False,
+        allow_agent=False,
+    ) as conn:
+        print("=== GET-CONFIG filtered (Cisco-IOS-XE-native) ===")
+        response = conn.get_config(
+            source="running",
+            filter=("subtree", to_ele(FILTER_XML)),
+        )
+        result = parse_response(str(response))
+        print(json.dumps(result, indent=2))
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

- Rewrote `labs/devnet-netconf/README.md`: bilingual (FR/EN), Cat8k IOS-XE 17.9 platform, `netconf-yang` enable steps, two-script table, key `filter=("subtree", to_ele(...))` callout, JSON output example
- Rewrote `netconf_get.py`: full running-config get with no filter, Python 3.8 compatible
- Added `netconf_interfaces.py`: filtered get via `Cisco-IOS-XE-native` YANG model, returns hostname + GigabitEthernet1 / Vlan20 / Vlan21 / VirtualPortGroup31 as JSON

## Test plan

- [ ] Verify README renders correctly on GitHub (bilingual tables, code blocks, JSON example)
- [ ] Check `netconf_get.py` connects and returns full XML config on a Cat8k 17.9 device
- [ ] Check `netconf_interfaces.py` returns valid JSON with the four expected interface keys
- [ ] Confirm missing env var triggers a clear error message and non-zero exit

https://claude.ai/code/session_01N75GEdsYBi1yP4vtyVXhb8

---
_Generated by [Claude Code](https://claude.ai/code/session_01N75GEdsYBi1yP4vtyVXhb8)_