### PR TITLE
lab bgp-filtering: BGP Filtering lab — Cat8k IOS-XE 17.12.2

### DIFF
--- a/labs/bgp-filtering/README.md
+++ b/labs/bgp-filtering/README.md
@@ -1,0 +1,182 @@
+# Lab BGP Filtering — Cisco Cat8k IOS-XE / BGP Filtering Lab — Cisco Cat8k IOS-XE
+
+**Status: Completed ✅**
+
+---
+
+## FR — Description
+
+Ce lab démontre les techniques de filtrage BGP sur un routeur Cisco Catalyst 8000V dans
+le sandbox DevNet. Quatre mécanismes de filtrage sont illustrés : prefix-list, ACL AS-path,
+route-map et communities BGP.
+
+| Paramètre | Valeur |
+|---|---|
+| Plateforme | Cisco Cat8k IOS-XE 17.12.2 |
+| Environnement | Cisco DevNet Sandbox |
+| AS local | 65001 |
+| AS pair | 65002 |
+| Router-ID | 2.2.2.2 |
+
+### Topologie
+
+```
+         AS 65001                      AS 65002
+  ┌─────────────────────┐       ┌──────────────────┐
+  │  Cat8k (2.2.2.2)    │       │  DevNet Peer     │
+  │                     │       │  10.10.20.50     │
+  │  Lo0  2.2.2.2/32    ├───────┤                  │
+  │  Lo1  172.16.1.0/24 │eBGP   │                  │
+  │  Lo2  192.168.20.0  │       │                  │
+  │  Gi1  10.10.20.254  │       │                  │
+  └─────────────────────┘       └──────────────────┘
+```
+
+### Préfixes annoncés dans BGP
+
+| Réseau | Masque | Annoncé vers AS65002 |
+|---|---|---|
+| 2.2.2.2 | /32 | ✅ (via PL-OUT) |
+| 172.16.1.0 | /24 | ✅ (via PL-OUT) |
+| 192.168.20.0 | /24 | ❌ (bloqué par PL-OUT) |
+
+### Techniques de filtrage
+
+#### 1. Prefix-list `PL-OUT`
+
+Filtre sortant : seuls `172.16.1.0/24` et `2.2.2.2/32` sont autorisés vers le pair.
+
+```
+ip prefix-list PL-OUT seq 10 permit 172.16.1.0/24
+ip prefix-list PL-OUT seq 20 permit 2.2.2.2/32
+ip prefix-list PL-OUT seq 30 deny 0.0.0.0/0 le 32
+```
+
+#### 2. ACL AS-path
+
+| ACL | Regex | Usage |
+|---|---|---|
+| 1 | `^$` | Routes originées localement (AS65001) |
+| 2 | `^65002$` | Routes reçues directement d'AS65002 |
+| 3 | `_65003_` | Blocage du transit via AS65003 |
+
+#### 3. Route-map `RM-OUT`
+
+Appliqué en sortie vers le voisin 10.10.20.50 :
+- Match `PL-OUT` → autorise les préfixes sélectionnés
+- Set `local-preference 200`
+- Set `community 65001:100`
+
+#### 4. Route-map `RM-COMMUNITY`
+
+Enrichissement des communities :
+- Match `PL-OUT` → set `community 65001:200 additive`
+
+### Vérification
+
+```
+show bgp ipv4 unicast summary
+show bgp ipv4 unicast neighbors 10.10.20.50 advertised-routes
+show bgp ipv4 unicast 172.16.1.0/24
+show ip prefix-list PL-OUT
+```
+
+---
+
+## EN — Description
+
+This lab demonstrates BGP filtering techniques on a Cisco Catalyst 8000V router inside
+the DevNet sandbox. Four filtering mechanisms are illustrated: prefix-list, AS-path ACL,
+route-map, and BGP communities.
+
+| Parameter | Value |
+|---|---|
+| Platform | Cisco Cat8k IOS-XE 17.12.2 |
+| Environment | Cisco DevNet Sandbox |
+| Local AS | 65001 |
+| Peer AS | 65002 |
+| Router-ID | 2.2.2.2 |
+
+### Topology
+
+```
+         AS 65001                      AS 65002
+  ┌─────────────────────┐       ┌──────────────────┐
+  │  Cat8k (2.2.2.2)    │       │  DevNet Peer     │
+  │                     │       │  10.10.20.50     │
+  │  Lo0  2.2.2.2/32    ├───────┤                  │
+  │  Lo1  172.16.1.0/24 │eBGP   │                  │
+  │  Lo2  192.168.20.0  │       │                  │
+  │  Gi1  10.10.20.254  │       │                  │
+  └─────────────────────┘       └──────────────────┘
+```
+
+### Prefixes advertised into BGP
+
+| Network | Mask | Advertised to AS65002 |
+|---|---|---|
+| 2.2.2.2 | /32 | ✅ (via PL-OUT) |
+| 172.16.1.0 | /24 | ✅ (via PL-OUT) |
+| 192.168.20.0 | /24 | ❌ (blocked by PL-OUT) |
+
+### Filtering techniques
+
+#### 1. Prefix-list `PL-OUT`
+
+Outbound filter: only `172.16.1.0/24` and `2.2.2.2/32` are allowed toward the peer.
+
+```
+ip prefix-list PL-OUT seq 10 permit 172.16.1.0/24
+ip prefix-list PL-OUT seq 20 permit 2.2.2.2/32
+ip prefix-list PL-OUT seq 30 deny 0.0.0.0/0 le 32
+```
+
+#### 2. AS-path ACLs
+
+| ACL | Regex | Usage |
+|---|---|---|
+| 1 | `^$` | Locally originated routes (AS65001) |
+| 2 | `^65002$` | Routes received directly from AS65002 |
+| 3 | `_65003_` | Block transit through AS65003 |
+
+#### 3. Route-map `RM-OUT`
+
+Applied outbound toward neighbor 10.10.20.50:
+- Match `PL-OUT` → allow selected prefixes
+- Set `local-preference 200`
+- Set `community 65001:100`
+
+#### 4. Route-map `RM-COMMUNITY`
+
+Community enrichment:
+- Match `PL-OUT` → set `community 65001:200 additive`
+
+### Verification
+
+```
+show bgp ipv4 unicast summary
+show bgp ipv4 unicast neighbors 10.10.20.50 advertised-routes
+show bgp ipv4 unicast 172.16.1.0/24
+show ip prefix-list PL-OUT
+```
+
+---
+
+## Output example / Exemple de sortie
+
+```
+Cat8k# show bgp ipv4 unicast summary
+BGP router identifier 2.2.2.2, local AS number 65001
+BGP table version is 7, main routing table version 7
+3 network entries using 744 bytes of memory
+
+Neighbor        V    AS MsgRcvd MsgSent TblVer InQ OutQ Up/Down  State/PfxRcd
+10.10.20.50     4 65002      12      14      7    0    0 00:08:21        2
+
+Cat8k# show bgp ipv4 unicast neighbors 10.10.20.50 advertised-routes
+   Network          Next Hop       Metric LocPrf Weight Path
+*> 2.2.2.2/32       10.10.20.254        0    200  32768 i
+*> 172.16.1.0/24    10.10.20.254        0    200  32768 i
+
+Total number of prefixes 2
+```

--- a/labs/bgp-filtering/cat8000v-config.txt
+++ b/labs/bgp-filtering/cat8000v-config.txt
@@ -1,0 +1,113 @@
+! ============================================================
+! Cisco Cat8k IOS-XE 17.12.2 — BGP Filtering Lab
+! AS 65001 | Router-ID 2.2.2.2
+! DevNet Sandbox — eBGP peer AS 65002 @ 10.10.20.50
+! ============================================================
+
+hostname Cat8k-BGP-Lab
+
+!
+! ── Interfaces ──────────────────────────────────────────────
+!
+interface Loopback0
+ description Router-ID / BGP prefix
+ ip address 2.2.2.2 255.255.255.255
+!
+interface Loopback1
+ description Internal subnet — advertised outbound
+ ip address 172.16.1.1 255.255.255.0
+!
+interface Loopback2
+ description Internal subnet — filtered outbound
+ ip address 192.168.20.1 255.255.255.0
+!
+interface GigabitEthernet1
+ description eBGP uplink to AS65002
+ ip address 10.10.20.254 255.255.255.0
+ negotiation auto
+ no shutdown
+!
+
+!
+! ── IP Routing ──────────────────────────────────────────────
+!
+ip routing
+ip bgp-community new-format
+
+!
+! ── Prefix-lists ────────────────────────────────────────────
+!
+ip prefix-list PL-OUT seq 10 permit 172.16.1.0/24
+ip prefix-list PL-OUT seq 20 permit 2.2.2.2/32
+ip prefix-list PL-OUT seq 30 deny 0.0.0.0/0 le 32
+
+!
+! ── AS-path access-lists ────────────────────────────────────
+!
+! ACL 1: permit only locally originated routes (empty AS-path)
+ip as-path access-list 1 permit ^$
+!
+! ACL 2: permit routes received directly from AS 65002
+ip as-path access-list 2 permit ^65002$
+!
+! ACL 3: deny routes that transited through AS 65003
+ip as-path access-list 3 deny _65003_
+ip as-path access-list 3 permit .*
+
+!
+! ── Route-maps ──────────────────────────────────────────────
+!
+! RM-OUT: outbound filter toward AS65002
+!   - match PL-OUT (allow 172.16.1.0/24 and 2.2.2.2/32)
+!   - set local-pref 200 and community 65001:100
+route-map RM-OUT permit 10
+ match ip address prefix-list PL-OUT
+ set local-preference 200
+ set community 65001:100
+route-map RM-OUT deny 20
+!
+! RM-COMMUNITY: additive community tagging for selected prefixes
+route-map RM-COMMUNITY permit 10
+ match ip address prefix-list PL-OUT
+ set community 65001:200 additive
+route-map RM-COMMUNITY deny 20
+
+!
+! ── BGP ─────────────────────────────────────────────────────
+!
+router bgp 65001
+ bgp router-id 2.2.2.2
+ bgp log-neighbor-changes
+ !
+ ! Advertise local prefixes into BGP table
+ network 2.2.2.2 mask 255.255.255.255
+ network 172.16.1.0 mask 255.255.255.0
+ network 192.168.20.0 mask 255.255.255.0
+ !
+ ! eBGP neighbor AS 65002
+ neighbor 10.10.20.50 remote-as 65002
+ neighbor 10.10.20.50 description DevNet-Peer-AS65002
+ neighbor 10.10.20.50 send-community
+ neighbor 10.10.20.50 route-map RM-OUT out
+ !
+ ! Address-family explicit config
+ address-family ipv4
+  network 2.2.2.2 mask 255.255.255.255
+  network 172.16.1.0 mask 255.255.255.0
+  network 192.168.20.0 mask 255.255.255.0
+  neighbor 10.10.20.50 activate
+  neighbor 10.10.20.50 send-community
+  neighbor 10.10.20.50 route-map RM-OUT out
+ exit-address-family
+
+!
+! ── Verification commands ────────────────────────────────────
+!
+! show bgp ipv4 unicast summary
+! show bgp ipv4 unicast neighbors 10.10.20.50 advertised-routes
+! show bgp ipv4 unicast 172.16.1.0/24
+! show bgp ipv4 unicast 192.168.20.0/24
+! show ip prefix-list PL-OUT
+! show ip as-path access-list
+! show route-map RM-OUT
+! show bgp ipv4 unicast community 65001:100


### PR DESCRIPTION
## Summary

- Added `labs/bgp-filtering/README.md`: bilingual (FR/EN), topology diagram AS65001↔AS65002, prefix table, four filtering techniques documented (prefix-list, AS-path ACL, route-map, communities), verification commands and sample output
- Added `labs/bgp-filtering/cat8000v-config.txt`: complete IOS-XE 17.12.2 config — Loopback0/1/2, GigabitEthernet1, `ip prefix-list PL-OUT`, AS-path ACLs 1/2/3, `route-map RM-OUT` (local-pref 200 + community 65001:100), `route-map RM-COMMUNITY` (community 65001:200 additive), `router bgp 65001` with three `network` statements and `neighbor 10.10.20.50 route-map RM-OUT out`

## Test plan

- [ ] Verify README tables and ASCII topology render correctly on GitHub
- [ ] Confirm `cat8000v-config.txt` pastes cleanly into an IOS-XE 17.12 device without syntax errors
- [ ] Check that `show bgp ipv4 unicast neighbors 10.10.20.50 advertised-routes` shows only 2.2.2.2/32 and 172.16.1.0/24 (192.168.20.0/24 filtered)
- [ ] Verify community 65001:100 is set on advertised prefixes

https://claude.ai/code/session_01N75GEdsYBi1yP4vtyVXhb8

---
_Generated by [Claude Code](https://claude.ai/code/session_01N75GEdsYBi1yP4vtyVXhb8)_