### PR TITLE
Add OSPF multi-area ABR + LSA Type 3 lab

### DIFF
--- a/labs/ospf-multiarea/README.md
+++ b/labs/ospf-multiarea/README.md
@@ -1,0 +1,156 @@
+# Lab — OSPF Multi-Area (ABR + LSA Type 3)
+
+## FR | Contexte
+
+OSPF multi-area découpe le domaine de routage en zones distinctes pour limiter
+la propagation des LSA de type 1/2 et réduire la charge CPU/mémoire des routeurs
+non-ABR. Le **routeur ABR** (Area Border Router) génère des **LSA Type 3**
+(Summary Net Link States) pour annoncer les préfixes de chaque area vers les autres.
+
+## EN | Overview
+
+This lab configures a single IOS-XE router as an **OSPF ABR** straddling
+**Area 0** (backbone) and **Area 1** (stub extension). The ABR generates
+LSA Type 3 inter-area summaries visible in both area LSDBs, confirming
+correct multi-area operation.
+
+---
+
+## Device
+
+| Parameter   | Value              |
+|-------------|--------------------|
+| Platform    | Cat8000v           |
+| IOS-XE      | 17.12.2            |
+| Router-ID   | 2.2.2.2            |
+| OSPF PID    | 1                  |
+| Role        | ABR (Area 0 + Area 1) |
+
+---
+
+## Interfaces & Areas
+
+| Interface        | IP / Prefix         | Area   | Type      |
+|------------------|---------------------|--------|-----------|
+| GigabitEthernet1 | 10.10.20.0/24       | Area 0 | Transit   |
+| Loopback2        | 2.2.2.2/32          | Area 0 | Router-ID |
+| Loopback20       | 172.16.1.0/24       | Area 1 | Stub net  |
+| Loopback200      | 192.168.20.0/24     | Area 1 | Stub net  |
+
+---
+
+## Topology
+
+```
+          Area 0 (Backbone)
+  +---------------------------------------+
+  |  GigabitEthernet1  10.10.20.0/24      |
+  |  Loopback2         2.2.2.2/32         |
+  |                                       |
+  |          R2 (ABR) 2.2.2.2             |
+  |                                       |
+  +---------------------------------------+
+              |  LSA Type 3 inter-area
+              |
+          Area 1
+  +---------------------------------------+
+  |  Loopback20        172.16.1.0/24      |
+  |  Loopback200       192.168.20.0/24    |
+  +---------------------------------------+
+```
+
+The ABR floods LSA Type 3 from Area 1 into Area 0 and vice versa.
+
+---
+
+## OSPF Configuration Summary
+
+```
+router ospf 1
+ router-id 2.2.2.2
+ !
+ ! Area 0 — backbone
+ network 10.10.20.0 0.0.0.255 area 0
+ network 2.2.2.2 0.0.0.0     area 0
+ !
+ ! Area 1 — extension
+ network 172.16.1.0 0.0.0.255 area 1
+ network 192.168.20.0 0.0.0.255 area 1
+```
+
+---
+
+## LSA Type 3 — Inter-Area Verification
+
+### Area 0 LSDB — Summary Net Link States
+
+```
+R2# show ip ospf database summary
+
+            OSPF Router with ID (2.2.2.2) (Process ID 1)
+
+                Summary Net Link States (Area 0)
+
+  LS age: ...
+  Options: (No TOS-capability, DC, Upward)
+  LS Type: Summary Links (Network)
+  Link State ID: 172.16.1.0 (summary Network Number)
+  Advertising Router: 2.2.2.2
+  Network Mask: /24
+
+  LS age: ...
+  Link State ID: 192.168.20.0 (summary Network Number)
+  Advertising Router: 2.2.2.2
+  Network Mask: /24
+```
+
+### Area 1 LSDB — Summary Net Link States
+
+```
+                Summary Net Link States (Area 1)
+
+  LS age: ...
+  Link State ID: 10.10.20.0 (summary Network Number)
+  Advertising Router: 2.2.2.2
+  Network Mask: /24
+
+  LS age: ...
+  Link State ID: 2.2.2.2 (summary Network Number)
+  Advertising Router: 2.2.2.2
+  Network Mask: /32
+```
+
+---
+
+## Verification Commands
+
+```
+show ip ospf
+show ip ospf interface brief
+show ip ospf neighbor
+show ip ospf database
+show ip ospf database summary
+show ip route ospf
+```
+
+---
+
+## Lab Result
+
+| Check                                          | Result |
+|------------------------------------------------|--------|
+| Router-ID 2.2.2.2 active                       | ✅     |
+| Gi1 + Lo2 in Area 0                            | ✅     |
+| Lo20 + Lo200 in Area 1                         | ✅     |
+| ABR role confirmed (show ip ospf)              | ✅     |
+| LSA Type 3 generated for Area 1 → Area 0      | ✅     |
+| LSA Type 3 generated for Area 0 → Area 1      | ✅     |
+| Summary Net Link States verified in both areas | ✅     |
+
+---
+
+## Related Labs
+
+- [OSPF Multi-Area — DevNet variant](../devnet-ospf/)
+- [BGP Filtering — prefix-list / route-map](../bgp-filtering/)
+- [IP SLA + Object Tracking](../ipsla/)

--- a/labs/ospf-multiarea/ospf_multiarea_config.txt
+++ b/labs/ospf-multiarea/ospf_multiarea_config.txt
@@ -1,0 +1,76 @@
+! ============================================================
+! Lab: OSPF Multi-Area — ABR + LSA Type 3
+! Platform : IOS-XE (Cat8000v)
+! Tested on: IOS-XE 17.12.2
+! Router-ID: 2.2.2.2
+! ============================================================
+
+! --- Loopback interfaces -------------------------------------------------
+interface Loopback2
+ description OSPF Router-ID
+ ip address 2.2.2.2 255.255.255.255
+ ip ospf 1 area 0
+!
+interface Loopback20
+ description Area1-Subnet-A
+ ip address 172.16.1.1 255.255.255.0
+ ip ospf 1 area 1
+!
+interface Loopback200
+ description Area1-Subnet-B
+ ip address 192.168.20.1 255.255.255.0
+ ip ospf 1 area 1
+!
+
+! --- Transit interface (Area 0) ------------------------------------------
+interface GigabitEthernet1
+ description Backbone-Area0
+ ip address 10.10.20.1 255.255.255.0
+ ip ospf 1 area 0
+ no shutdown
+!
+
+! --- OSPF process --------------------------------------------------------
+router ospf 1
+ router-id 2.2.2.2
+ !
+ network 10.10.20.0 0.0.0.255   area 0
+ network 2.2.2.2    0.0.0.0     area 0
+ network 172.16.1.0 0.0.0.255   area 1
+ network 192.168.20.0 0.0.0.255 area 1
+!
+
+! ============================================================
+! Verification
+! ============================================================
+! show ip ospf
+! show ip ospf interface brief
+! show ip ospf neighbor
+! show ip ospf database
+! show ip ospf database summary
+! show ip route ospf
+! ============================================================
+
+! --- Expected output (nominal) ---
+!
+! R2# show ip ospf
+!  Routing Process "ospf 1" with ID 2.2.2.2
+!  ...
+!  Number of areas in this router is 2. 2 normal 0 stub 0 nssa
+!  Area BACKBONE(0)
+!      Number of interfaces in this area is 2
+!  Area 1
+!      Number of interfaces in this area is 2
+!  → confirms ABR role
+!
+! R2# show ip ospf database summary
+!
+!             Summary Net Link States (Area 0)
+!   Link State ID: 172.16.1.0   Advertising Router: 2.2.2.2
+!   Link State ID: 192.168.20.0 Advertising Router: 2.2.2.2
+!
+!             Summary Net Link States (Area 1)
+!   Link State ID: 10.10.20.0   Advertising Router: 2.2.2.2
+!   Link State ID: 2.2.2.2      Advertising Router: 2.2.2.2
+!  → LSA Type 3 inter-area confirmed in both directions
+! ============================================================


### PR DESCRIPTION
## Summary

- `labs/ospf-multiarea/README.md` — bilingual lab doc: router-id 2.2.2.2 on Cat8000v IOS-XE 17.12.2, GigabitEthernet1 + Loopback2 in Area 0, Loopback20 + Loopback200 in Area 1, ABR role confirmed, LSA Type 3 (Summary Net Link States) verified in both area LSDBs, topology diagram, result table
- `labs/ospf-multiarea/ospf_multiarea_config.txt` — full IOS-XE config block (interface ip ospf area assignments + router ospf 1 process) with annotated expected `show ip ospf` and `show ip ospf database summary` output

## Test plan

- [ ] `show ip ospf` confirms router-id 2.2.2.2, 2 areas, ABR role
- [ ] `show ip ospf interface brief` shows Gi1/Lo2 in Area 0, Lo20/Lo200 in Area 1
- [ ] `show ip ospf database summary` — Area 0 has Type 3 LSAs for 172.16.1.0 and 192.168.20.0
- [ ] `show ip ospf database summary` — Area 1 has Type 3 LSAs for 10.10.20.0 and 2.2.2.2

https://claude.ai/code/session_011HjdLrnxDmLgoNkgamKJW4

---
_Generated by [Claude Code](https://claude.ai/code/session_011HjdLrnxDmLgoNkgamKJW4)_