### PR TITLE
Mark fortinet-dmz-industrial lab as completed, update topology

### DIFF
--- a/README.md
+++ b/README.md
@@ -261,7 +261,7 @@ creds = vault.decrypt("<ENCRYPTED-BLOB-HERE>")
 | `qos` | IOS-XE · MQC · class-map · priority · bandwidth | ✅ Complété |
 | **Firewall** | | |
 | `firewall/checkpoint-basics` | R81.x · SmartConsole · VPN | 📅 Planifié |
-| `firewall/fortinet-dmz-industrial` | FortiOS 7.x · IT/OT · IDMZ | 🚧 En cours |
+| `firewall/fortinet-dmz-industrial` | FortiOS 7.x · IT/OT · IDMZ | ✅ Complété |
 | `firewall/stormshield-sns` | SNS OS · IPS ASQ · VPN SSL/IPSec | 📅 Planifié |
 | **Security Services** | | |
 | `security-services/ids-ips-suricata` | Suricata · ELK · custom rules | 🚧 En cours |

--- a/labs/firewall/fortinet-dmz-industrial/README.md
+++ b/labs/firewall/fortinet-dmz-industrial/README.md
@@ -11,21 +11,18 @@
 ## Topologie prévue / Planned Topology
 
 ```
-[Topology placeholder — full diagram to be added]
-
   Internet
      |
- [FortiGate] (perimeter)
-  /    |    \
-LAN   DMZ   OT Network
-(IT)  (Web, (SCADA,
-      SFTP)  Historian)
+[FGT-EDGE 600E]  WAN | DMZ-IT 172.16.10.0/24 | LAN-IT 10.0.10.0/24
+     |
+[FGT-INTERNAL 200F]  DMZ-IT-ext 172.16.10.2/24 | DMZ-OT 172.16.20.0/24 | LAN-OT 172.16.30.0/24
 
-  LAN  ──►  DMZ   : allowed (restricted)
-  LAN  ──►  OT    : denied by default
-  DMZ  ──►  OT    : denied
-  OT   ──►  DMZ   : historian polling only (port 443)
-  OT   ──►  Internet : denied
+  LAN-IT  ──►  DMZ-IT   : Jump Server (SSH/RDP), Historian (HTTPS) — allowed
+  LAN-IT  ──►  Internet  : HTTP/HTTPS via SNAT (AppCtrl + URLfilter)
+  LAN-IT  ──►  LAN-OT   : denied — must go via Jump Server in DMZ-IT
+  DMZ-OT  ──►  LAN-OT   : OPC-UA historian polling only (IPS strict)
+  LAN-OT  ──►  Internet  : denied absolute
+  LAN-OT  ──►  LAN-IT   : denied absolute
 ```
 
 **Équipements / Equipment:** FortiGate VM (FortiOS 7.x) + FortiSwitch simulé
@@ -34,7 +31,7 @@ LAN   DMZ   OT Network
 
 ## Statut / Status
 
-🚧 En cours de construction
+✅ Complété / Completed
 
 ---
 


### PR DESCRIPTION
## Summary

- `labs/firewall/fortinet-dmz-industrial/README.md`:
  - Status `🚧 En cours de construction` → `✅ Complété / Completed`
  - Topology placeholder replaced with actual diagram from configs:
    - FGT-EDGE 600E: WAN / DMZ-IT `172.16.10.0/24` / LAN-IT `10.0.10.0/24`
    - FGT-INTERNAL 200F: DMZ-IT-ext / DMZ-OT `172.16.20.0/24` / LAN-OT `172.16.30.0/24`
    - Flow matrix derived from firewall policies (allow/deny rules)
- `README.md` labs table: `firewall/fortinet-dmz-industrial` row `🚧 En cours` → `✅ Complété`

## Test plan

- [ ] Verify lab README shows `✅ Complété / Completed` in the Status section
- [ ] Verify topology block reflects actual FGT-EDGE and FGT-INTERNAL addressing
- [ ] Verify main README labs table row shows `✅ Complété`

https://claude.ai/code/session_01WhkunCMs3hBxyLSmLXmAY9

---
_Generated by [Claude Code](https://claude.ai/code/session_01WhkunCMs3hBxyLSmLXmAY9)_