### PR TITLE
Mark ids-ips-suricata lab as completed, update topology

### DIFF
--- a/README.md
+++ b/README.md
@@ -264,7 +264,7 @@ creds = vault.decrypt("<ENCRYPTED-BLOB-HERE>")
 | `firewall/fortinet-dmz-industrial` | FortiOS 7.x · IT/OT · IDMZ | ✅ Complété |
 | `firewall/stormshield-sns` | SNS OS · IPS ASQ · VPN SSL/IPSec | 📅 Planifié |
 | **Security Services** | | |
-| `security-services/ids-ips-suricata` | Suricata · ELK · custom rules | 🚧 En cours |
+| `security-services/ids-ips-suricata` | Suricata · ELK · custom rules | ✅ Complété |
 | `security-services/radius-dot1x` | FreeRADIUS · 802.1X · MAB · Cisco | ✅ Complété |
 | `security-services/vpn-ipsec-site-to-site` | FortiGate · IKEv2 · AES-256-GCM · X.509 | ✅ Complété |
 | **OT Industrial** | | |

--- a/labs/security-services/ids-ips-suricata/README.md
+++ b/labs/security-services/ids-ips-suricata/README.md
@@ -11,19 +11,11 @@
 ## Topologie prévue / Planned Topology
 
 ```
-[Topology placeholder — full diagram to be added]
-
-Mode IDS (passive / SPAN port):
-[Switch]──SPAN port──►[Suricata IDS]──►[ELK Stack (Kibana)]
-    |
-[LAN clients + servers]
-
-Mode IPS (inline):
-[Router/FW]──►[Suricata IPS (NFQUEUE/AF_PACKET)]──►[LAN]
-                   |
-              Block / Alert
-                   |
-            [ELK Stack (Kibana)]
+  Mode IDS (passive AF_PACKET / SPAN):
+  [Switch SPAN] → [Suricata 7.x Ubuntu 22.04] → EVE JSON → [Filebeat] → [ELK Stack / Kibana]
+  Mode IPS (inline NFQUEUE):
+  [FGT-INTERNAL] → [Suricata NFQUEUE bridge] → [LAN-OT] | Drop/Alert → [ELK Stack]
+  HOME_NET: 10.0.10.0/24, 172.16.10-20-30.0/24 | OT protocols: Modbus/DNP3/S7Comm/OPC-UA/EIP
 ```
 
 **Équipements / Equipment:** Suricata VM (Linux) + ELK Stack VM + réseau de test
@@ -32,7 +24,7 @@ Mode IPS (inline):
 
 ## Statut / Status
 
-🚧 En cours de construction
+✅ Complété / Completed
 
 ---
 


### PR DESCRIPTION
## Summary

- `labs/security-services/ids-ips-suricata/README.md`:
  - Status `🚧 En cours de construction` → `✅ Complété / Completed`
  - Topology placeholder replaced with actual deployment info from `suricata.yaml` and `custom-rules.rules`:
    - IDS mode: Switch SPAN → Suricata 7.x → EVE JSON → Filebeat → ELK/Kibana
    - IPS mode: FGT-INTERNAL → Suricata NFQUEUE bridge → LAN-OT
    - HOME_NET ranges and OT protocol stack (Modbus/DNP3/S7Comm/OPC-UA/EIP)
- `README.md` labs table: `security-services/ids-ips-suricata` row `🚧 En cours` → `✅ Complété`

## Test plan

- [ ] Verify lab README shows `✅ Complété / Completed` in the Status section
- [ ] Verify topology block reflects actual Suricata deployment modes and network vars
- [ ] Verify main README labs table row shows `✅ Complété`

https://claude.ai/code/session_01WhkunCMs3hBxyLSmLXmAY9

---
_Generated by [Claude Code](https://claude.ai/code/session_01WhkunCMs3hBxyLSmLXmAY9)_