### PR TITLE
docs(stormshield-sns): update status to Planned

### DIFF
--- a/labs/firewall/stormshield-sns/README.md
+++ b/labs/firewall/stormshield-sns/README.md
@@ -30,7 +30,7 @@
 
 ## Statut / Status
 
-🚧 En cours de construction
+📅 Planifié / Planned
 
 ---
 


### PR DESCRIPTION
$(cat <<'EOF'
## Summary

- Updates `labs/firewall/stormshield-sns/README.md`: replaces `🚧 En cours de construction` with `📅 Planifié / Planned`
- Main `README.md` already had `📅 Planifié` for this lab — no change needed there

## Note

The main README Labs table (line 265) was already consistent with the planned status, so only the lab-level README required the update.

https://claude.ai/code/session_01XGyyyvGqvoDJ67aZ5SQ3YM
EOF
)

---
_Generated by [Claude Code](https://claude.ai/code/session_01XGyyyvGqvoDJ67aZ5SQ3YM)_