### PR TITLE
fix: point HNO Nightly Check badge to branch=principal

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 ### Administrateur Réseaux & Télécoms | NetDevOps Engineer
 
 [![GitHub](https://img.shields.io/badge/GitHub-oumeziane69--prog-181717?style=flat-square&logo=github)](https://github.com/oumeziane69-prog)
-[![HNO Nightly Check](https://github.com/oumeziane69-prog/network-portfolio/actions/workflows/hno-nightly-check.yml/badge.svg?branch=main)](https://github.com/oumeziane69-prog/network-portfolio/actions/workflows/hno-nightly-check.yml)
+[![HNO Nightly Check](https://github.com/oumeziane69-prog/network-portfolio/actions/workflows/hno-nightly-check.yml/badge.svg?branch=principal)](https://github.com/oumeziane69-prog/network-portfolio/actions/workflows/hno-nightly-check.yml)
 [![LinkedIn](https://img.shields.io/badge/LinkedIn-Profil-0077B5?style=flat-square&logo=linkedin)](https://www.linkedin.com/in/oumeziane69/)
 [![▶ Formation YouTube](https://img.shields.io/badge/▶_Formation-YouTube-red?logo=youtube)](https://youtu.be/3CaPH8SWNH4)
 [![CV](https://img.shields.io/badge/CV-PDF-blue?style=flat-square&logo=adobeacrobatreader)](https://raw.githubusercontent.com/oumeziane69-prog/network-portfolio/main/docs/cv-hakim-oumeziane.pdf)


### PR DESCRIPTION
## Summary
- Updated HNO Nightly Check badge URL in README.md: changed `?branch=main` to `?branch=principal` so the badge reflects the correct workflow branch status.

## Test plan
- [ ] Verify the badge in the rendered README points to the `principal` branch workflow run


---
_Generated by [Claude Code](https://claude.ai/code/session_014Prk7QhKLzd9CKSAoBfxRs)_