### PR TITLE
docs: add 10 Cat8000v items to roadmap - all completed

### DIFF
--- a/README.md
+++ b/README.md
@@ -321,6 +321,16 @@ Pipeline CI/CD complet pour automatiser le déploiement de configurations résea
 | CI/CD NetDevOps pipeline | Documentation | Python | High | ✅ Completed |
 | NSE4 Fortinet ([study guide](docs/certif-prep/nse4-study-guide.md) · [cheatsheet](docs/certif-prep/nse4-cheatsheet.md)) | Certification | Fortinet | High | 🔨 In Progress |
 | DevNet Associate | Certification | Cisco | High | 🎯 Roadmap |
+| Cat8000v OSPF multi-area | Lab | Cisco IOS-XE | High | ✅ Completed |
+| Cat8000v GRE Tunnel | Lab | Cisco IOS-XE | High | ✅ Completed |
+| Cat8000v QoS LLQ | Lab | Cisco IOS-XE | Medium | ✅ Completed |
+| Cat8000v SD-WAN lite | Lab | Cisco IOS-XE | High | ✅ Completed |
+| Cat8000v BGP communities | Lab | Cisco IOS-XE | High | ✅ Completed |
+| Cat8000v NAT overload | Lab | Cisco IOS-XE | Medium | ✅ Completed |
+| Cat8000v EIGRP+OSPF redistribution | Lab | Cisco IOS-XE | High | ✅ Completed |
+| Cat8000v HSRP/VRRP | Lab | Cisco IOS-XE | Medium | ✅ Completed |
+| Cat8000v ACL time-based | Lab | Cisco IOS-XE | Medium | ✅ Completed |
+| Netmiko backup script Cat8000v | Script | Python/Netmiko | High | ✅ Completed |
 
 ---
 


### PR DESCRIPTION
## Summary

- Add 9 Cat8000v lab rows to the Roadmap table: OSPF multi-area, GRE Tunnel, QoS LLQ, SD-WAN lite, BGP communities, NAT overload, EIGRP+OSPF redistribution, HSRP/VRRP, ACL time-based
- Add 1 Netmiko backup script row: `Netmiko backup script Cat8000v`
- All 10 items marked ✅ Completed
- Rows appended after existing roadmap entries, before NSE4/DevNet certifications remain unchanged

## Test plan

- [ ] Roadmap table renders correctly on GitHub (18 rows total)
- [ ] All 10 new rows show ✅ Completed status
- [ ] Existing rows (NSE4, DevNet Associate) unchanged

https://claude.ai/code/session_01PqynrB3y45K1eb7GhJoVhX

---
_Generated by [Claude Code](https://claude.ai/code/session_01PqynrB3y45K1eb7GhJoVhX)_