### PR TITLE
fix(readme): cache_seconds=1800 on stats cards + migrate streak to demolab

### DIFF
--- a/README.md
+++ b/README.md
@@ -288,11 +288,11 @@ Pipeline CI/CD complet pour automatiser le déploiement de configurations résea
 
 <div align="center">
 
-![GitHub Stats](https://github-readme-stats.vercel.app/api?username=oumeziane69-prog&show_icons=true&theme=dark&hide_border=true&count_private=true)
+![GitHub Stats](https://github-readme-stats.vercel.app/api?username=oumeziane69-prog&show_icons=true&theme=dark&hide_border=true&count_private=true&cache_seconds=1800)
 
-![Top Languages](https://github-readme-stats.vercel.app/api/top-langs/?username=oumeziane69-prog&layout=compact&theme=dark&hide_border=true)
+![Top Languages](https://github-readme-stats.vercel.app/api/top-langs/?username=oumeziane69-prog&layout=compact&theme=dark&hide_border=true&cache_seconds=1800)
 
-![GitHub Streak](https://github-readme-streak-stats.herokuapp.com/?user=oumeziane69-prog&theme=dark&hide_border=true)
+![GitHub Streak](https://streak-stats.demolab.com/?user=oumeziane69-prog&theme=dark&hide_border=true)
 
 </div>
 


### PR DESCRIPTION
## Summary

- **GitHub Stats** & **Top Languages**: added `&cache_seconds=1800` to reduce rate-limit errors on vercel.app
- **GitHub Streak**: migrated from `github-readme-streak-stats.herokuapp.com` (deprecated/unreliable) to `streak-stats.demolab.com` (official maintained host)

## Test plan

- [ ] Open README.md preview on GitHub — verify all 3 stat cards render correctly
- [ ] Confirm streak card displays with the new demolab.com URL
- [ ] Confirm no broken image badges

https://claude.ai/code/session_01BQ7i9xbTs1kPD8pSZW9aFk

---
_Generated by [Claude Code](https://claude.ai/code/session_01BQ7i9xbTs1kPD8pSZW9aFk)_