### PR TITLE
fix(readme): migrate stats cards to salesp07 vercel instance

### DIFF
--- a/README.md
+++ b/README.md
@@ -293,9 +293,9 @@ Pipeline CI/CD complet pour automatiser le déploiement de configurations résea
 
 <div align="center">
 
-![GitHub Stats](https://github-readme-stats.vercel.app/api?username=oumeziane69-prog&show_icons=true&theme=dark&hide_border=true&count_private=true&cache_seconds=1800)
+![GitHub Stats](https://github-readme-stats-salesp07.vercel.app/api?username=oumeziane69-prog&show_icons=true&theme=dark&hide_border=true&count_private=true)
 
-![Top Languages](https://github-readme-stats.vercel.app/api/top-langs/?username=oumeziane69-prog&layout=compact&theme=dark&hide_border=true&cache_seconds=1800)
+![Top Languages](https://github-readme-stats-salesp07.vercel.app/api/top-langs/?username=oumeziane69-prog&layout=compact&theme=dark&hide_border=true)
 
 ![GitHub Streak](https://streak-stats.demolab.com/?user=oumeziane69-prog&theme=dark&hide_border=true)
 


### PR DESCRIPTION
## Summary

- **GitHub Stats** & **Top Languages**: migrated from `github-readme-stats.vercel.app` to `github-readme-stats-salesp07.vercel.app` (community fork, more reliable and rate-limit-free)
- Removed `cache_seconds=1800` param (no longer needed with this host)
- Streak card (`streak-stats.demolab.com`) unchanged

## Test plan

- [ ] Open README.md preview on GitHub — verify GitHub Stats card renders correctly
- [ ] Verify Top Languages card renders correctly
- [ ] Confirm no broken image badges

https://claude.ai/code/session_01BQ7i9xbTs1kPD8pSZW9aFk

---
_Generated by [Claude Code](https://claude.ai/code/session_01BQ7i9xbTs1kPD8pSZW9aFk)_